### PR TITLE
Add Supabase database schema and client configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,10 @@ LOG_LEVEL=info
 COPILOT_CLOUD_API_KEY=
 # Optional: Only needed if using CopilotKit Cloud features
 
-# Database (if applicable)
-# DATABASE_URL=
+# Supabase Configuration
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # Privacy & Local-First Settings
 # Set to 'true' to enforce local-only mode (no external API calls except configured ones)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@copilotkit/react-core": "1.50.0",
     "@copilotkit/react-ui": "^0.2.0",
     "@copilotkit/runtime": "1.50.0",
+    "@supabase/supabase-js": "^2.49.0",
     "next": "^16.1.1",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,7 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "./types";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey);

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,11 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "./types";
+
+export function createServiceClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,0 +1,253 @@
+// Auto-generate with: npx supabase gen types typescript --project-id <your-project-id> > src/lib/supabase/types.ts
+// This is a manual baseline matching the migration schema.
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      profiles: {
+        Row: {
+          id: string;
+          display_name: string | null;
+          avatar_url: string | null;
+          role: "user" | "admin" | "consultant";
+          preferences: Json;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id: string;
+          display_name?: string | null;
+          avatar_url?: string | null;
+          role?: "user" | "admin" | "consultant";
+          preferences?: Json;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          display_name?: string | null;
+          avatar_url?: string | null;
+          role?: "user" | "admin" | "consultant";
+          preferences?: Json;
+          updated_at?: string;
+        };
+      };
+      projects: {
+        Row: {
+          id: string;
+          owner_id: string;
+          name: string;
+          description: string | null;
+          settings: Json;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          owner_id: string;
+          name: string;
+          description?: string | null;
+          settings?: Json;
+        };
+        Update: {
+          name?: string;
+          description?: string | null;
+          settings?: Json;
+        };
+      };
+      conversations: {
+        Row: {
+          id: string;
+          project_id: string;
+          user_id: string;
+          title: string | null;
+          agent_model: string;
+          metadata: Json;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          project_id: string;
+          user_id: string;
+          title?: string | null;
+          agent_model?: string;
+          metadata?: Json;
+        };
+        Update: {
+          title?: string | null;
+          agent_model?: string;
+          metadata?: Json;
+        };
+      };
+      messages: {
+        Row: {
+          id: string;
+          conversation_id: string;
+          role: "user" | "assistant" | "system" | "tool";
+          content: string;
+          tool_calls: Json | null;
+          metadata: Json;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          conversation_id: string;
+          role: "user" | "assistant" | "system" | "tool";
+          content: string;
+          tool_calls?: Json | null;
+          metadata?: Json;
+        };
+        Update: {
+          content?: string;
+          metadata?: Json;
+        };
+      };
+      ui_elements: {
+        Row: {
+          id: string;
+          conversation_id: string;
+          element_key: string;
+          element_type: "StatCard" | "DataTable" | "ChartCard" | "Custom";
+          props: Json;
+          position: number;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          conversation_id: string;
+          element_key: string;
+          element_type: "StatCard" | "DataTable" | "ChartCard" | "Custom";
+          props?: Json;
+          position?: number;
+        };
+        Update: {
+          element_key?: string;
+          element_type?: "StatCard" | "DataTable" | "ChartCard" | "Custom";
+          props?: Json;
+          position?: number;
+        };
+      };
+      toolsets: {
+        Row: {
+          id: string;
+          name: string;
+          description: string | null;
+          icon: string | null;
+          is_default: boolean;
+          tools: string[];
+          category: string | null;
+          status: "active" | "deprecated" | "experimental" | "beta";
+          version: string;
+          metadata: Json;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id: string;
+          name: string;
+          description?: string | null;
+          icon?: string | null;
+          is_default?: boolean;
+          tools?: string[];
+          category?: string | null;
+          status?: "active" | "deprecated" | "experimental" | "beta";
+          version?: string;
+          metadata?: Json;
+        };
+        Update: {
+          name?: string;
+          description?: string | null;
+          tools?: string[];
+          status?: "active" | "deprecated" | "experimental" | "beta";
+          version?: string;
+          metadata?: Json;
+        };
+      };
+      audit_log: {
+        Row: {
+          id: string;
+          user_id: string | null;
+          project_id: string | null;
+          action: string;
+          entity_type: string;
+          entity_id: string | null;
+          details: Json;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id?: string | null;
+          project_id?: string | null;
+          action: string;
+          entity_type: string;
+          entity_id?: string | null;
+          details?: Json;
+        };
+        Update: never;
+      };
+      journal_entries: {
+        Row: {
+          id: string;
+          user_id: string;
+          content: string;
+          tags: string[];
+          embedding: number[] | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          content: string;
+          tags?: string[];
+          embedding?: number[] | null;
+        };
+        Update: {
+          content?: string;
+          tags?: string[];
+          embedding?: number[] | null;
+        };
+      };
+      file_uploads: {
+        Row: {
+          id: string;
+          project_id: string;
+          user_id: string;
+          file_name: string;
+          file_path: string;
+          file_size: number | null;
+          mime_type: string | null;
+          category: "raw" | "processed" | "reports";
+          storage_bucket: string;
+          metadata: Json;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          project_id: string;
+          user_id: string;
+          file_name: string;
+          file_path: string;
+          file_size?: number | null;
+          mime_type?: string | null;
+          category?: "raw" | "processed" | "reports";
+          storage_bucket?: string;
+          metadata?: Json;
+        };
+        Update: {
+          file_name?: string;
+          metadata?: Json;
+        };
+      };
+    };
+  };
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,17 @@
+[project]
+id = "modme-genui"
+name = "ModMe GenUI Workspace"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public"]
+extra_search_path = ["public"]
+
+[db]
+port = 54322
+major_version = 15
+
+[studio]
+enabled = true
+port = 54323

--- a/supabase/migrations/00001_initial_schema.sql
+++ b/supabase/migrations/00001_initial_schema.sql
@@ -1,0 +1,316 @@
+-- ============================================
+-- ModMe GenUI Workspace - Supabase Database
+-- Initial Schema Migration
+-- ============================================
+
+-- Enable required extensions
+create extension if not exists "uuid-ossp";
+create extension if not exists "pgcrypto";
+
+-- ============================================
+-- 1. Users & Profiles
+-- ============================================
+
+create table public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  display_name text,
+  avatar_url text,
+  role text not null default 'user' check (role in ('user', 'admin', 'consultant')),
+  preferences jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.profiles enable row level security;
+
+create policy "Users can view own profile"
+  on public.profiles for select
+  using (auth.uid() = id);
+
+create policy "Users can update own profile"
+  on public.profiles for update
+  using (auth.uid() = id);
+
+-- Auto-create profile on signup
+create or replace function public.handle_new_user()
+returns trigger as $$
+begin
+  insert into public.profiles (id, display_name)
+  values (new.id, new.raw_user_meta_data->>'display_name');
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- ============================================
+-- 2. Projects / Workspaces
+-- ============================================
+
+create table public.projects (
+  id uuid primary key default uuid_generate_v4(),
+  owner_id uuid not null references public.profiles(id) on delete cascade,
+  name text not null,
+  description text,
+  settings jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.projects enable row level security;
+
+create policy "Owners can manage their projects"
+  on public.projects for all
+  using (auth.uid() = owner_id);
+
+create index idx_projects_owner on public.projects(owner_id);
+
+-- ============================================
+-- 3. Conversations (Agent chat sessions)
+-- ============================================
+
+create table public.conversations (
+  id uuid primary key default uuid_generate_v4(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  title text,
+  agent_model text not null default 'gemini-2.5-flash',
+  metadata jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.conversations enable row level security;
+
+create policy "Users can manage own conversations"
+  on public.conversations for all
+  using (auth.uid() = user_id);
+
+create index idx_conversations_project on public.conversations(project_id);
+create index idx_conversations_user on public.conversations(user_id);
+
+-- ============================================
+-- 4. Messages
+-- ============================================
+
+create table public.messages (
+  id uuid primary key default uuid_generate_v4(),
+  conversation_id uuid not null references public.conversations(id) on delete cascade,
+  role text not null check (role in ('user', 'assistant', 'system', 'tool')),
+  content text not null,
+  tool_calls jsonb,
+  metadata jsonb not null default '{}',
+  created_at timestamptz not null default now()
+);
+
+alter table public.messages enable row level security;
+
+create policy "Users can access messages in own conversations"
+  on public.messages for all
+  using (
+    exists (
+      select 1 from public.conversations c
+      where c.id = conversation_id and c.user_id = auth.uid()
+    )
+  );
+
+create index idx_messages_conversation on public.messages(conversation_id);
+create index idx_messages_created on public.messages(conversation_id, created_at);
+
+-- ============================================
+-- 5. UI Elements (GenUI rendered components)
+-- ============================================
+
+create table public.ui_elements (
+  id uuid primary key default uuid_generate_v4(),
+  conversation_id uuid not null references public.conversations(id) on delete cascade,
+  element_key text not null,
+  element_type text not null check (element_type in ('StatCard', 'DataTable', 'ChartCard', 'Custom')),
+  props jsonb not null default '{}',
+  position int not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.ui_elements enable row level security;
+
+create policy "Users can access UI elements in own conversations"
+  on public.ui_elements for all
+  using (
+    exists (
+      select 1 from public.conversations c
+      where c.id = conversation_id and c.user_id = auth.uid()
+    )
+  );
+
+create index idx_ui_elements_conversation on public.ui_elements(conversation_id);
+
+-- ============================================
+-- 6. Toolsets
+-- ============================================
+
+create table public.toolsets (
+  id text primary key,
+  name text not null,
+  description text,
+  icon text,
+  is_default boolean not null default false,
+  tools text[] not null default '{}',
+  category text check (category in (
+    'generative_ui', 'data_analysis', 'frontend', 'backend',
+    'system', 'integration', 'testing', 'knowledge_management'
+  )),
+  status text not null default 'active' check (status in ('active', 'deprecated', 'experimental', 'beta')),
+  version text not null default '1.0.0',
+  metadata jsonb not null default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.toolsets enable row level security;
+
+create policy "Toolsets are readable by authenticated users"
+  on public.toolsets for select
+  using (auth.role() = 'authenticated');
+
+create policy "Only admins can modify toolsets"
+  on public.toolsets for all
+  using (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid() and p.role = 'admin'
+    )
+  );
+
+-- ============================================
+-- 7. Audit Log
+-- ============================================
+
+create table public.audit_log (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references public.profiles(id) on delete set null,
+  project_id uuid references public.projects(id) on delete set null,
+  action text not null,
+  entity_type text not null,
+  entity_id text,
+  details jsonb not null default '{}',
+  created_at timestamptz not null default now()
+);
+
+alter table public.audit_log enable row level security;
+
+create policy "Users can view own audit entries"
+  on public.audit_log for select
+  using (auth.uid() = user_id);
+
+create policy "System can insert audit entries"
+  on public.audit_log for insert
+  with check (auth.uid() = user_id);
+
+create index idx_audit_log_user on public.audit_log(user_id);
+create index idx_audit_log_project on public.audit_log(project_id);
+create index idx_audit_log_action on public.audit_log(action);
+create index idx_audit_log_created on public.audit_log(created_at desc);
+
+-- ============================================
+-- 8. Journal Entries (private notes)
+-- ============================================
+
+create table public.journal_entries (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  content text not null,
+  tags text[] not null default '{}',
+  embedding vector(768),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.journal_entries enable row level security;
+
+create policy "Users can manage own journal entries"
+  on public.journal_entries for all
+  using (auth.uid() = user_id);
+
+create index idx_journal_user on public.journal_entries(user_id);
+create index idx_journal_tags on public.journal_entries using gin(tags);
+
+-- ============================================
+-- 9. File Uploads (data directory equivalent)
+-- ============================================
+
+create table public.file_uploads (
+  id uuid primary key default uuid_generate_v4(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  file_name text not null,
+  file_path text not null,
+  file_size bigint,
+  mime_type text,
+  category text not null default 'raw' check (category in ('raw', 'processed', 'reports')),
+  storage_bucket text not null default 'project-files',
+  metadata jsonb not null default '{}',
+  created_at timestamptz not null default now()
+);
+
+alter table public.file_uploads enable row level security;
+
+create policy "Users can manage own file uploads"
+  on public.file_uploads for all
+  using (auth.uid() = user_id);
+
+create index idx_file_uploads_project on public.file_uploads(project_id);
+
+-- ============================================
+-- 10. Updated_at trigger function
+-- ============================================
+
+create or replace function public.update_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+-- Apply updated_at triggers
+create trigger set_updated_at before update on public.profiles
+  for each row execute function public.update_updated_at();
+
+create trigger set_updated_at before update on public.projects
+  for each row execute function public.update_updated_at();
+
+create trigger set_updated_at before update on public.conversations
+  for each row execute function public.update_updated_at();
+
+create trigger set_updated_at before update on public.ui_elements
+  for each row execute function public.update_updated_at();
+
+create trigger set_updated_at before update on public.toolsets
+  for each row execute function public.update_updated_at();
+
+create trigger set_updated_at before update on public.journal_entries
+  for each row execute function public.update_updated_at();
+
+-- ============================================
+-- 11. Storage Buckets
+-- ============================================
+
+insert into storage.buckets (id, name, public)
+values ('project-files', 'project-files', false);
+
+create policy "Users can upload to own project files"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'project-files' and
+    auth.role() = 'authenticated'
+  );
+
+create policy "Users can read own project files"
+  on storage.objects for select
+  using (
+    bucket_id = 'project-files' and
+    auth.role() = 'authenticated'
+  );


### PR DESCRIPTION
Sets up the full Supabase database with tables for profiles, projects,
conversations, messages, UI elements, toolsets, audit log, journal entries,
and file uploads. Includes RLS policies, auto-timestamps, and TypeScript types.

https://claude.ai/code/session_01Avoz2TfXKh3DZpUQouJnjs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Supabase as the app database with a complete schema, RLS, and typed clients for browser and server. This enables secure, typed access for profiles, projects, conversations, messages, UI elements, toolsets, audit logs, journals, and file uploads.

- **New Features**
  - Database schema with RLS, indices, and updated_at triggers for the above tables.
  - Storage bucket project-files with read/write policies for authenticated users.
  - Typed Supabase clients: browser anon client and server service-role client.
  - Added Database TypeScript types and @supabase/supabase-js dependency.
  - Supabase local config (config.toml) and env keys in .env.example.

- **Migration**
  - Set NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY in .env.
  - Apply migrations: supabase db push (local) or deploy via your Supabase project, then link/push.
  - Optional: regenerate types after deploy: npx supabase gen types typescript --project-id <project-id> > src/lib/supabase/types.ts.

<sup>Written for commit dcd4aebf2ce9d9ddc472c993a6345cfe8a62b5c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

