### PR TITLE
feat(onboard): agent index, beads CI wiring, and onboarding delta

### DIFF
--- a/.agents/skills/cicd-automation-workflow-automate/SKILL.md
+++ b/.agents/skills/cicd-automation-workflow-automate/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: cicd-automation-workflow-automate
+description: Design and implement CI/CD pipelines, GitHub Actions workflows, and automated development processes for Monorepo_ModMe. Use when consolidating workflows, adding verify scripts, or closing CI coverage gaps.
+---
+
+# CI/CD Workflow Automation — Monorepo_ModMe
+
+Repo-specific overlay for pipeline design. Pair with [`.agents/skills/github-actions-efficiency/SKILL.md`](../github-actions-efficiency/SKILL.md) for cost/runtime audits.
+
+## Current architecture
+
+| Layer | Scope |
+|-------|-------|
+| `.github/workflows/ci.yml` | secret-guard (always) + path-filtered GenerativeUI, next-forge, agent-server |
+| `.github/workflows/pre-commit-check.yml` | Policy checks via `scripts/pre-commit-checks.mjs --ci` |
+| `.github/workflows/changelog-check.yml` | PR changelog require-update |
+| `.github/workflows/launch-json-check.yml` | launch.json ↔ manifest sync |
+| `.buildkite/pipeline.yml` | GenerativeUI lint/test/build |
+
+## Local CI parity
+
+```powershell
+yarn verify:forge          # next-forge check + test + build
+yarn verify:generative     # GenerativeUI lint + test + build
+yarn pre-commit:check      # staged-aware hook checks
+```
+
+## Phased improvement backlog
+
+### Phase A — Deduplication (done / maintain)
+
+- Changelog validation owned by `changelog-check.yml` (not duplicated in `ci.yml`)
+- `pre-commit-check.yml` runs policy only; stack builds in `ci.yml`
+- `secret-guard` runs on every push/PR (no doc-only workflow skip)
+
+### Phase B — Coverage
+
+- `yarn verify:generative` at root
+- `agent-server` pytest job in `ci.yml`
+- `agenttrace-ci` on `main` and `dev`
+
+### Phase C — Quality gates (planned)
+
+- Prisma format check in next-forge CI
+- `bun run boundaries` in next-forge CI
+- Complete `docs/codebase/TESTING.md`
+
+### Phase D — Deploy (needs approval)
+
+- GitHub Environments + staging on merge to `dev`
+- Document dormant `GenerativeUI_monorepo/.github/workflows/` as inactive
+
+### Phase E — Agent task memory (beads)
+
+Git-backed issue tracking for multi-session CI and migration work.
+
+```powershell
+yarn beads:init              # bd init --prefix modme + 5 starter issues
+npx @beads/bd ready          # pick next unblocked issue at session start
+npx @beads/bd close modme-N  # when task ships
+```
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/init-beads-starter-issues.ps1` | Idempotent init + seed from `docs/beads-workflow.md` |
+| `docs/beads-workflow.md` | Prefix, starter issue table, beads vs chat todos |
+
+Wire beads into onboarding: `/init` Phase 1 → `yarn beads:init` → Phase 4 issues pre-seeded.
+
+## Safety
+
+- Avoid deployment steps without approvals and rollback plans.
+- Treat secrets and environment configuration changes as high risk.
+- Never commit `.env` files; use `secret-guard` patterns from `scripts/pre-commit-checks.mjs`.
+
+## References
+
+- [`docs/agent-index.md`](../../docs/agent-index.md) — CI summary
+- [`docs/buildkite-guide.md`](../../docs/buildkite-guide.md)
+- [`scripts/pre-commit-checks.mjs`](../../scripts/pre-commit-checks.mjs)

--- a/.agents/skills/framework-migration-code-migrate/SKILL.md
+++ b/.agents/skills/framework-migration-code-migrate/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: framework-migration-code-migrate
+description: Framework migration assistant for Monorepo_ModMe. Routes GenerativeUI → next-forge work to the authoritative modme-generative-ui-migrate playbook.
+---
+
+# Framework Migration — Monorepo_ModMe
+
+This skill is a **router** for cross-stack migration in this repository. The authoritative playbook is:
+
+**[`.agents/skills/modme-generative-ui-migrate/SKILL.md`](../modme-generative-ui-migrate/SKILL.md)**
+
+Read that skill before porting code. Do not cross-import monorepos.
+
+## Migration phases (summary)
+
+| Phase | Status | Deliverable |
+|-------|--------|-------------|
+| 1 Workshop | In progress | `next-forge/apps/storybook/stories/modme-workshop.stories.tsx` |
+| 2 Schemas | Done | `next-forge/packages/schemas` (`@repo/schemas`) |
+| 3 Client island | Done | `next-forge/apps/app/app/(authenticated)/generative-ui/` |
+| 4 Cutover | Pending | Feature flags, deprecate web-dashboard |
+
+## What migrates vs stays
+
+| Migrate | Stay in GenerativeUI |
+|---------|---------------------|
+| GenerativeCanvas, useAgentState | agent-server (Python satellite) |
+| shared-schemas → `@repo/schemas` | vibe-web-app, example-*, agent-generator |
+| web-dashboard routes → apps/app | UniversalWorkbench copies |
+
+## Boundaries
+
+- No `workspace:*` imports between `next-forge/` and `GenerativeUI_monorepo/`.
+- Integration via HTTP/WebSocket only (`NEXT_PUBLIC_AGENT_SERVER_WS_URL`).
+- Rollback: `yarn dev:generative` + disable feature flags in next-forge.
+
+## Verification
+
+```powershell
+yarn dev:forge:core      # next-forge app on 3100
+yarn dev:generative      # legacy stack; agent-server on 8000
+yarn verify:forge        # before next-forge PR
+```
+
+## References
+
+- [`docs/agent-index.md`](../../docs/agent-index.md)
+- [`docs/codebase/ARCHITECTURE.md`](../../docs/codebase/ARCHITECTURE.md)
+- [`docs/codebase/STRUCTURE.md`](../../docs/codebase/STRUCTURE.md)

--- a/.agents/skills/modme-generative-ui-migrate/SKILL.md
+++ b/.agents/skills/modme-generative-ui-migrate/SKILL.md
@@ -60,9 +60,10 @@ Document-first migration. **Do not** cross-import monorepos. GenerativeUI stays 
 
 - [ ] Storybook stories match GenerativeCanvas UX
 - [ ] WebSocket connects to agent-server on worktree port
-- [ ] `@repo/schemas` types match shared-schemas
+- [x] `@repo/schemas` types match shared-schemas
 - [ ] `yarn dev:generative` and `yarn dev:forge` run concurrently without port clash
 - [ ] `bun run build` passes in next-forge
+- [x] Client island at `apps/app/(authenticated)/generative-ui/`
 
 ## References
 

--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,76 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+embeddeddolt/
+proxieddb/
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+proxied_server_client_info.json
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+export-state.json
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+
+# Debug-mode pprof artifacts (written when dolt.debug: true in config.yaml)
+dolt-pprof/
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Sync-ready**: Uses Dolt remotes for backup and team sharing
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Dolt-native sync via bd dolt push / bd dolt pull
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,68 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, .beads/issues.jsonl is the only local store
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# Dolt-native backup (periodic backup for off-machine recovery)
+# This is full database backup only. Cross-machine sync uses Dolt remotes.
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-backups
+#   git-push: false    # Disable git push (backup locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Optional JSONL auto-export for viewers, interchange, and issue-level migration.
+# Disabled by default; enable only when an integration needs fresh .beads/issues.jsonl.
+# Use relative paths under .beads/ for JSONL import/export filenames.
+# export:
+#   auto: false
+#   path: issues.jsonl
+#   interval: 60s
+#   git-add: false
+# import:
+#   path: issues.jsonl
+
+# Integration settings (access with 'bd config get/set')
+# Non-secret keys (stored in the database):
+# - jira.url, jira.project
+# - linear.team_id
+# - github.org, github.repo
+#
+# Secret keys (stored in this file but prefer env vars to avoid git exposure):
+# - linear.api_key  → use LINEAR_API_KEY env var instead
+# - github.token    → use GITHUB_TOKEN env var instead
+
+sync.remote: "git+https://github.com/Ditto190/modme-ui-01.git"

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.5 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  else
+    echo >&2 "beads: hook 'post-checkout' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
+    bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.5 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.5 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+  else
+    echo >&2 "beads: hook 'post-merge' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
+    bd hooks run post-merge "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.5 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Installed by scripts/install-git-hooks.ps1
+set -e
+node scripts/pre-commit-checks.mjs
+
+# --- BEGIN BEADS INTEGRATION v1.0.5 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  else
+    echo >&2 "beads: hook 'pre-commit' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
+    bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.5 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.5 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+  else
+    echo >&2 "beads: hook 'pre-push' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
+    bd hooks run pre-push "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.5 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.5 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  else
+    echo >&2 "beads: hook 'prepare-commit-msg' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
+    bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'prepare-commit-msg'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.5 ---

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "modme",
+  "project_id": "ec33729a-24b4-4030-bac3-0d5c6a151077"
+}

--- a/.cursor/commands/init.md
+++ b/.cursor/commands/init.md
@@ -5,9 +5,9 @@ argument-hint: [beads-prefix]
 
 # Project init — Monorepo_ModMe
 
-Run this when joining the repo or starting a new agent session. Complete **all three phases** unless the user only asked for one.
+Run this when joining the repo or starting a new agent session. Complete **four phases** unless the user only asked for one.
 
-Optional argument `$ARGUMENTS`: beads issue prefix (e.g. `modme` → `modme-1`, `modme-2`). Default: directory name `Monorepo_ModMe`.
+Optional argument `$ARGUMENTS`: beads issue prefix (e.g. `modme` → `modme-1`, `modme-2`). Default: `modme`.
 
 ---
 
@@ -18,8 +18,9 @@ Initialize persistent, git-backed task memory for multi-session work.
 1. Check whether beads is already initialized (`.beads/` exists or `bd stats` succeeds).
 2. If **not** initialized:
    - Use the beads MCP `init` tool with prefix from `$ARGUMENTS` (or `modme` if empty).
+   - Fallback (no MCP): `yarn beads:init` or `bd init --prefix modme` from repo root.
    - Report database location and issue prefix.
-   - Suggest `/beads:workflow` and creating the first issue with `/beads:create`.
+   - Suggest creating issues via beads MCP `create` or `/beads:create` when available.
 3. If **already** initialized:
    - Use beads MCP `stats` and summarize open/ready issues.
    - Do not re-init.
@@ -30,19 +31,19 @@ Initialize persistent, git-backed task memory for multi-session work.
 
 ## Phase 2 — VS Code / Cursor debug setup
 
-This repo ships curated debug configs. Verify they are usable and explain them to the user.
+This repo ships curated debug configs for **both** monorepos. Verify they are usable and explain them to the user.
 
 ### Key files
 
 | File | Purpose |
 |------|---------|
 | `.vscode/launch.json` | Debug configurations (Run and Debug panel) |
-| `.vscode/tasks.json` | `preLaunchTask` helpers (Vite dev, agent-generator build) |
+| `.vscode/tasks.json` | `preLaunchTask` helpers (Vite dev, agent-generator build, forge docs/storybook) |
 | `scripts/launch-manifest.json` | Source of truth for app names, ports, cwds |
 | `scripts/validate-launch-json.mjs` | Local + CI validator |
 | `docs/debug-launch-guide.md` | Human/agent guide for debugging |
 
-### Debug targets (ports)
+### Debug targets — GenerativeUI (legacy)
 
 | Configuration | Stack | Port |
 |---------------|-------|------|
@@ -51,21 +52,33 @@ This repo ships curated debug configs. Verify they are usable and explain them t
 | Agent Server (FastAPI) | Python / uvicorn | 8000 |
 | Example Next / React | Template packages | 3002 / 3003 |
 
-**Compound launches:** `Full Stack: Agent Server + Web Dashboard` and `Full Stack: Agent Server + Vibe Web App`.
+**Compounds:** `Full Stack: Agent Server + Web Dashboard`, `Full Stack: Agent Server + Vibe Web App`.
+
+### Debug targets — next-forge (primary)
+
+| Configuration | Stack | Port |
+|---------------|-------|------|
+| next-forge App (SaaS) | Next 16 + Bun | 3100 |
+| next-forge Web (Marketing) | Next 16 + Bun | 3101 |
+| next-forge API | Next 16 + Bun | 3102 |
+| next-forge Docs (Mintlify) | Mintlify | 3104 |
+| next-forge Storybook (Workshop) | Storybook 10 | 6106 |
+
+**Compound:** `Full Stack: Forge Core + Agent Server` (3100–3102 + 8000).
 
 ### Prerequisites checklist
 
 Run or instruct the user to run:
 
 ```powershell
-# Node monorepo
-cd GenerativeUI_monorepo
-yarn install
+# next-forge (primary)
+yarn dev:forge:supabase          # Docker Supabase
+cd next-forge && bun install && bun run db:push
+# copy next-forge/.env.example → .env.local (Auth.js dev@modme.local)
 
-# Python agent server (pick one)
-cd apps/agent-server
-poetry install
-# or: python -m venv venv; .\venv\Scripts\activate; pip install -r requirements.txt
+# GenerativeUI (legacy)
+cd GenerativeUI_monorepo && yarn install
+cd apps/agent-server && poetry install
 
 # Root env (variable names only — never commit values)
 # Copy .env.example → .env if needed; OPENAI_API_KEY, PORT, etc.
@@ -86,7 +99,7 @@ If validation fails, read `docs/debug-launch-guide.md` § "Adding a new app" and
 ### How to start debugging (user)
 
 1. Open **Run and Debug** (`Ctrl+Shift+D`).
-2. Pick a configuration from the dropdown (e.g. `Web Dashboard (Next.js)`).
+2. Pick a configuration from the dropdown (e.g. `next-forge App (SaaS)` or `Web Dashboard (Next.js)`).
 3. Press **F5**.
 4. For full stack, use a **compound** configuration.
 
@@ -99,15 +112,23 @@ Point the user (or future agents) to the layered docs:
 | Layer | File | Use when |
 |-------|------|----------|
 | Entry | `AGENTS.md` | Commands, layout, agent behavior |
+| **Index** | `docs/agent-index.md` | Dual-monorepo map, ports, skills, drift register |
 | Deep guide | `docs/agent-tech-guide.md` | lean-ctx, skills, changelog, CI, **debug** |
 | Debug focus | `docs/debug-launch-guide.md` | launch.json setup, ports, CI sync |
+| Worktrees | `docs/multi-agent-worktrees.md` | **Mandatory** for feature work |
+| Stack | `docs/codebase/STACK.md` | Package managers, ports, setup status |
+| Migration | `.agents/skills/modme-generative-ui-migrate/SKILL.md` | GenerativeUI → next-forge phases |
+| CI automation | `.agents/skills/cicd-automation-workflow-automate/SKILL.md` | Pipeline design and consolidation |
+| Buildkite | `docs/buildkite-guide.md` | GenerativeUI Buildkite pipeline |
 | Changelog | `CHANGELOG.md` | Notable changes under `[Unreleased]` |
 | lean-ctx | `docs/lean-ctx-guide.md` | Context compression diagnostics |
+
+**Key repo skills:** `next-forge`, `modme-generative-ui-migrate`, `smart-git-automation`, `github-actions-efficiency`.
 
 **End-of-session checklist** (from agent-tech-guide):
 
 1. Append `CHANGELOG.md` if change is notable.
-2. Update `AGENTS.md` if commands/layout changed.
+2. Update `AGENTS.md` or `docs/agent-index.md` if commands/layout changed.
 3. Update `docs/agent-tech-guide.md` or `docs/debug-launch-guide.md` if tooling/workflows changed.
 4. Run `node scripts/validate-changelog.mjs --require-update` before push when monitored paths changed.
 
@@ -117,11 +138,13 @@ Point the user (or future agents) to the layered docs:
 
 If beads was just initialized, offer to create starter issues:
 
-1. **chore**: Verify local debug — run compound `Full Stack: Agent Server + Web Dashboard`
-2. **chore**: Confirm `yarn install` + `poetry install` documented in onboarding
-3. **task**: Any active feature the user is working on
+1. **chore**: Verify compound `Full Stack: Forge Core + Agent Server`
+2. **chore**: CI Phase A dedupe — confirm pre-commit vs ci.yml split
+3. **task**: Migration Phase 4 — feature-flag cutover for generative-ui route
+4. **chore**: Confirm `yarn verify:forge` + `yarn verify:generative` documented
+5. **task**: Any active feature the user is working on
 
-Use `/beads:create` or the beads MCP `create` tool.
+Use beads MCP `create` or `/beads:create` when available.
 
 ---
 
@@ -131,7 +154,7 @@ After running, respond with:
 
 1. **Beads** — initialized or stats summary
 2. **Debug** — which configs exist, prerequisites met/missing, validation result
-3. **Docs** — links to `docs/debug-launch-guide.md` and `docs/agent-tech-guide.md`
-4. **Next step** — one concrete action (F5 a config, install deps, or `/beads:create`)
+3. **Docs** — links to `docs/agent-index.md`, `docs/debug-launch-guide.md`, and `docs/agent-tech-guide.md`
+4. **Next step** — one concrete action (F5 a config, install deps, or create first beads issue)
 
 Do not commit `.env` or print secret values.

--- a/.cursor/rules/monorepo-modme.mdc
+++ b/.cursor/rules/monorepo-modme.mdc
@@ -1,27 +1,40 @@
 ﻿---
-description: "Monorepo_ModMe project context â€” Turborepo layout, package boundaries, and verification expectations."
+name: monorepo-modme
+description: Monorepo_ModMe layout — next-forge primary, GenerativeUI legacy
 globs: GenerativeUI_monorepo/**/*
 alwaysApply: false
 ---
 
-# Monorepo_ModMe
+# Monorepo_ModMe — GenerativeUI (legacy stack)
 
 ## Layout
-- Primary work happens under `GenerativeUI_monorepo/`.
+
+- **Primary product stack:** `next-forge/` (Bun, `@repo/*`) — new features land here.
+- **Legacy agent stack:** `GenerativeUI_monorepo/` (Yarn 3.3, Turbo) — maintained until migration cutover.
 - Yarn 3 workspaces: `apps/*`, `packages/*`.
-- Turbo orchestrates `dev`, `build`, `lint`, `test` from the monorepo root.
+- Turbo orchestrates `dev`, `build`, `lint`, `test` from the GenerativeUI monorepo root.
 
 ## Editing rules
+
 - Change only packages affected by the task.
 - Prefer `workspace:*` for internal dependencies.
 - Match the linter/formatter already configured in each package (ESLint or Biome).
 - UniversalWorkbench has its own root `package.json`; do not assume scripts from the template monorepo root.
+- Do **not** add cross-monorepo imports to `next-forge/` — see `monorepo-boundaries.mdc`.
+
+## Migration pointer
+
+Porting GenerativeUI UI to next-forge: [`.agents/skills/modme-generative-ui-migrate/SKILL.md`](../../.agents/skills/modme-generative-ui-migrate/SKILL.md).
 
 ## Verification
+
 - Run the nearest package's `test`, `lint:check` or `lint`, and `type-check` when available.
+- Root: `yarn verify:generative` for CI parity.
 - For UI changes in Vite apps, run `dev` or `build` in that app package.
 
 ## AI asset locations
+
 - Rules: `.cursor/rules/`
 - Skills: `.agents/skills/` and `.cursor/skills/`
 - Copilot: `.github/copilot-instructions.md`
+- Index: [`docs/agent-index.md`](../../docs/agent-index.md)

--- a/.github/workflows/agenttrace-ci.yml
+++ b/.github/workflows/agenttrace-ci.yml
@@ -2,9 +2,9 @@ name: Agenttrace CI
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main", "dev"]
   push:
-    branches: [ "main" ]
+    branches: ["main", "dev"]
 
 jobs:
   agenttrace:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,8 @@ name: CI
 on:
   push:
     branches: [main, master, develop, dev]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "LICENSE"
   pull_request:
     branches: [main, master, develop, dev]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "LICENSE"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -40,6 +32,7 @@ jobs:
     outputs:
       forge: ${{ steps.filter.outputs.forge }}
       generative: ${{ steps.filter.outputs.generative }}
+      agent_server: ${{ steps.filter.outputs.agent_server }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -50,21 +43,8 @@ jobs:
               - 'next-forge/**'
             generative:
               - 'GenerativeUI_monorepo/**'
-
-  changelog:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Validate CHANGELOG
-        run: node scripts/validate-changelog.mjs
-      - name: Require CHANGELOG update when needed
-        env:
-          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
-        run: node scripts/validate-changelog.mjs --require-update
+            agent_server:
+              - 'GenerativeUI_monorepo/apps/agent-server/**'
 
   monorepo:
     needs: [secret-guard, changes]
@@ -97,6 +77,33 @@ jobs:
 
       - name: Build
         run: yarn build
+
+  agent-server:
+    needs: [secret-guard, changes]
+    if: needs.changes.outputs.agent_server == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: GenerativeUI_monorepo/apps/agent-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Test
+        run: poetry run pytest
 
   next-forge:
     needs: [secret-guard, changes]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -143,6 +143,48 @@
       "program": "${file}",
       "cwd": "${fileDirname}",
       "console": "integratedTerminal"
+    },
+    {
+      "name": "next-forge App (SaaS)",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "bun run dev",
+      "cwd": "${workspaceFolder}/next-forge/apps/app",
+      "serverReadyAction": {
+        "pattern": "- Local:\\s+(https?://\\S+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    },
+    {
+      "name": "next-forge Web (Marketing)",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "bun run dev",
+      "cwd": "${workspaceFolder}/next-forge/apps/web"
+    },
+    {
+      "name": "next-forge API",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "bun run dev",
+      "cwd": "${workspaceFolder}/next-forge/apps/api"
+    },
+    {
+      "name": "next-forge Docs (Mintlify)",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "bun run dev",
+      "cwd": "${workspaceFolder}/next-forge/apps/docs",
+      "preLaunchTask": "forge-docs: dev"
+    },
+    {
+      "name": "next-forge Storybook (Workshop)",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "bun run dev",
+      "cwd": "${workspaceFolder}/next-forge/apps/storybook",
+      "preLaunchTask": "forge-storybook: dev"
     }
   ],
   "compounds": [
@@ -160,6 +202,19 @@
       "stopAll": true,
       "presentation": {
         "order": 2
+      }
+    },
+    {
+      "name": "Full Stack: Forge Core + Agent Server",
+      "configurations": [
+        "Agent Server (FastAPI)",
+        "next-forge App (SaaS)",
+        "next-forge Web (Marketing)",
+        "next-forge API"
+      ],
+      "stopAll": true,
+      "presentation": {
+        "order": 3
       }
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,6 +46,50 @@
         "reveal": "always",
         "panel": "shared"
       }
+    },
+    {
+      "label": "forge-docs: dev",
+      "type": "shell",
+      "command": "bun run dev",
+      "options": {
+        "cwd": "${workspaceFolder}/next-forge/apps/docs"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "mintlify",
+        "pattern": { "regexp": "^$" },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "(ready|Local:\\s+http://localhost:3104)"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "forge-storybook: dev",
+      "type": "shell",
+      "command": "bun run dev",
+      "options": {
+        "cwd": "${workspaceFolder}/next-forge/apps/storybook"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "storybook",
+        "pattern": { "regexp": "^$" },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "(Local:\\s+http://localhost:6106|ready in \\d+)"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,6 @@ Root `AGENTS.md` and `.cursor/rules/` are hand-maintained — use contextarch fo
 - [`docs/agent-tech-guide.md`](docs/agent-tech-guide.md) — lean-ctx, skills, changelog, CI, debug
 - [`docs/debug-launch-guide.md`](docs/debug-launch-guide.md) — VS Code `launch.json`, ports, CI validation
 - [`docs/multi-agent-worktrees.md`](docs/multi-agent-worktrees.md) — mandatory for feature work
-- [`docs/inbox-pipeline/README.md`](docs/inbox-pipeline/README.md) — **Inbox → Knowledge pipeline** (feature taxonomy, mermaid architecture, all scripts + DB + UI + workflows)
 - [`CHANGELOG.md`](CHANGELOG.md) — append under `[Unreleased]` per Agent Update Protocol
 - [`docs/codebase/STACK.md`](docs/codebase/STACK.md) — dual-monorepo dependency scorecard and ports
 - [`.agents/skills/next-forge/SKILL.md`](.agents/skills/next-forge/SKILL.md) — next-forge agent skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,71 +61,48 @@ CI runs `node scripts/validate-changelog.mjs` on pull requests. See `docs/agent-
 
 ### Added
 
+- (docs) [`docs/agent-index.md`](docs/agent-index.md) — dual-monorepo agent onboarding index (ports, skills, migration status, drift register)
+- (cursor) Expanded `/init` command — beads fallback, next-forge debug targets, worktree/migration/CI doc map, Phase 4 starter issues
+- (debug) next-forge launch.json configs (app, web, api, docs, storybook) + compound `Full Stack: Forge Core + Agent Server`
+- (next-forge) `@repo/schemas` package — Zod types ported from GenerativeUI shared-schemas
+- (next-forge) Generative UI client island at `apps/app/(authenticated)/generative-ui/` with WebSocket hook
+- (ci) `yarn verify:generative` and `scripts/verify-generative-ci.ps1` for GenerativeUI CI parity
+- (ci) agent-server pytest job in `ci.yml` (path-filtered)
+- (docs) [`docs/beads-workflow.md`](docs/beads-workflow.md) — beads starter issues and `modme` prefix init guide
 - (cursor) Cursor marketplace plugin skills under `.cursor/skills/` — thermos, fix-ci, orchestrate, principle-*, voltagent, and related agent workflows
-- (copilot) Expanded root `.github/copilot-instructions.md` for dual-monorepo (next-forge + GenerativeUI) commands and verification workflow
-- (cursor) Additional Claude plugin enables in `.cursor/settings.json` (commit-commands, supabase, typescript-lsp, rust-analyzer-lsp, agent-sdk-dev)
+- (copilot) Expanded root `.github/copilot-instructions.md` for dual-monorepo commands and verification workflow
+- (cursor) Additional Claude plugin enables in `.cursor/settings.json`
 
 ### Changed
 
-- (gitignore) Ignore local hook state (`.cursor/hooks/state/`), IDE-local dirs (`.claude/`, `.copilot/`), and install manifests; remove erroneous `.cursor/hooks.json` ignore
-
-- (ci) next-forge CI job in `.github/workflows/ci.yml` — path-filtered `check`, `test`, `build` on Bun; `dev` branch added to workflow triggers
-- (ci) Root scripts `yarn check:forge`, `fix:forge`, `verify:forge`, `pre-commit:check`, `hooks:install`; `scripts/verify-forge-ci.ps1`
-- (ci) Pre-commit runs `ultracite check` when staged paths include `next-forge/`; changelog monitoring extended to next-forge apps/packages
-- (agents) ModMe overlay `.agents/skills/smart-git-automation/SKILL.md` and `scripts/vibe-session-finish.ps1` for worktree session end (commit/PR to `dev`)
-- (cursor) Cursor hook configuration simplified to prevent failClosed blocking issues
-- (next-forge) Root scripts `yarn dev:forge:core`, `dev:forge:workshop`, `dev:forge:supabase`
-- (cursor-cookbook) `dag-task-runner` skill at `.cursor/skills/dag-task-runner/` with Cursor SDK runner scripts
-- (cursor-cookbook) SDK examples vendored at `.vendor/cursor-cookbook/sdk/` (quickstart, app-builder, agent-kanban, coding-agent-cli, dag-task-runner)
-- (cursor-cookbook) `scripts/install-cursor-cookbook.ps1` to refresh hooks, skill, and SDK from upstream
-
-### Removed
-
-- (cursor) Problematic hooks removed from project — `audit-log.sh`, `block-models-by-repo-origin.sh`, `sensitive-prompt-guard.sh` were causing `ERROR_HOOKS_BLOCKED` in Cursor due to `failClosed: true` configuration and missing dependencies
-- (cursor) Hook patching logic from `install-cursor-cookbook.ps1` — hooks no longer available upstream
-- (cursor-ai) `agent-workbench-orchestration` skill — multi-agent workflow for agent panel work (schemas → hook → UI → WebSocket → verify) with goal contract template
-- (contextarch) [contextarch-cli](https://github.com/ksoventures/contextarch-cli) — install/bootstrap scripts, `yarn contextarch` / `yarn contextarch:bootstrap`; generated `next-forge` AI context files (AGENTS.md, CLAUDE.md, `.cursorrules`, `.github/copilot-instructions.md`)
-- (shared-schemas) WebSocket stream event payloads: `token`, `tool_start`, `tool_result`, `done`, plus `OptimisticMessage` schema
-- (web-dashboard) `AgentPanelSkeleton`, `StreamingText`, optimistic send/cancel/retry in `useAgentState`, glass agent panel in `GenerativeCanvas`
-- (agent-server) Token/tool streaming over `/ws/agent` with cancel support
-
-- (ci) Pre-commit checks — `scripts/pre-commit-checks.mjs`, `.githooks/pre-commit`, `scripts/install-git-hooks.ps1`; wired into GitHub Actions (`pre-commit-check.yml`) and Buildkite
-- (ci) `scripts/validate-cursor-skills.mjs` for awesome-cursor-skills install integrity (`--project-only` for hooks, full check for setup audits)
-- (ci) Buildkite pipeline for `GenerativeUI_monorepo` — `.buildkite/`, `docs/buildkite-guide.md`, `scripts/buildkite-demo.ps1`
-- (web-dashboard) Interactive Buildkite explainer at `/dev/buildkite`
-- Agent documentation stack: `docs/agent-tech-guide.md`, root `CHANGELOG.md`, and `changelog-check` CI workflow
-- Globally installed Cursor skills: `changelog-automation`, `documentation-writer`, `doc-coauthoring`, `agents-md`, `changelog-generator`
-- (cursor-ai) Remote Buildkite MCP server in `.cursor/mcp.json` with OAuth setup documented in `docs/agent-tech-guide.md`
-- (mcp) Mantine MCP server (`@mantine/mcp-server`) in `.cursor/mcp.json`, `.vscode/mcp.json`, `.github/mcp.json`, `GenerativeUI_monorepo/mcp.json`, and `.gitlab/duo/mcp.json`
-- (cursor-ai) Expanded [awesome-cursor-skills](https://github.com/spencerpauly/awesome-cursor-skills) global install set and project pointer at `.cursor/skills/awesome-cursor-skills/`
-- (dev) `scripts/install-direnv-hook.ps1`, root `.envrc`, and PowerShell 7 direnv hook for auto-loading `.env`
-- (agents) Multi-agent Git worktrees — `.cursor/worktrees.json`, `scripts/init-worktrees.ps1`, `scripts/new-agent-worktree.ps1`, per-worktree port allocation, `docs/multi-agent-worktrees.md`
-- (dev) `scripts/install-pwsh-terminal-hooks.ps1` — safe Cursor/VS Code shell integration + direnv hook; fixes pwsh startup errors
+- (agents) `AGENTS.md` — link agent-index, dedupe worktrees, clarify next-forge as primary stack, add verify:generative
+- (agents) `.cursor/rules/monorepo-modme.mdc` — legacy stack wording; pointer to next-forge for new features
+- (ci) Remove duplicate changelog job from `ci.yml`; secret-guard runs on all pushes/PRs (no doc-only skip)
+- (ci) `pre-commit-checks.mjs --ci` policy-only; stack builds stay in `ci.yml`
+- (ci) agenttrace-ci triggers on `dev` branch in addition to `main`
+- (ci) next-forge CI job in `.github/workflows/ci.yml` — path-filtered check, test, build on Bun
+- (ci) Root scripts `yarn check:forge`, `fix:forge`, `verify:forge`, `pre-commit:check`, `hooks:install`
+- (agents) ModMe overlay `smart-git-automation` skill and `vibe-session-finish.ps1` for worktree session end
+- (next-forge) Auth.js credentials + Supabase local Postgres (replaces Clerk/Neon for local dev)
+- (gitignore) Ignore local hook state, IDE-local dirs, and install manifests
 
 ### Fixed
 
-- (dev) `init-worktrees.ps1` — use `$LASTEXITCODE` for git branch detection; disable direnv during setup (no spurious `direnv: error` / `branch already exists`)
-- (dev) `new-agent-worktree.ps1` — usage help when `-Name` omitted; `DIRENV_DISABLE` during creation; default `-Owner cursor`
-- (vscode) Set `git.path` in `.vscode/settings.json` so Cursor Agent Review finds Git on Windows when it is not on PATH
-- Add `install-direnv.ps1` helper script to install direnv on Windows to resolve "direnv: command not found" terminal errors.
-- (agent-server) WebSocket message handling uses `asyncio.create_task` + lock so cancel does not block the receive loop
-
-### Changed
-
-- (ci) Worktree bootstrap (`setup-worktree-windows.ps1`, `setup-worktree-unix.sh`, `new-agent-worktree.ps1`) auto-installs git pre-commit hooks
-- (next-forge) Replace Clerk with Auth.js credentials in `@repo/auth`; replace Neon adapter with Supabase local Postgres + Prisma
-- (docs/ci) Post-restart agent tooling validation: lean-ctx 3.7.5, skills-sh MCP, global skills, changelog-check CI â€” all verified; installed `internal-comms` globally
-
-### Deprecated
-
-- (none)
+- (dev) Worktree scripts — `$LASTEXITCODE` for git branch detection; `DIRENV_DISABLE` during setup
+- (vscode) `git.path` in settings for Cursor Agent Review on Windows
+- (agent-server) WebSocket cancel uses asyncio.create_task + lock
 
 ### Removed
 
-- (cursor) Removed focus-stealing stop hooks (`update-skills-on-stop`, ralph `stop-hook`, continual-learning stop, `capture-response`); disabled `continual-learning` and `ralph-loop` plugins
+- (cursor) Problematic hooks removed — `audit-log.sh`, `block-models-by-repo-origin.sh`, `sensitive-prompt-guard.sh`
+- (cursor) Hook patching logic from `install-cursor-cookbook.ps1`
+
+### Deprecated
+
+- (GenerativeUI) `web-dashboard` — migrate to `next-forge/apps/app/(authenticated)/generative-ui/` per migration skill Phase 4
 
 ### Security
 
 - (none)
 
-<!-- Version compare links added on first tagged release, e.g. [1.0.0]: https://github.com/org/repo/compare/v0.9.0...v1.0.0 -->
+<!-- Version compare links added on first tagged release -->

--- a/GenerativeUI_monorepo/AGENTS.md
+++ b/GenerativeUI_monorepo/AGENTS.md
@@ -22,9 +22,7 @@ This Turborepo-powered monorepo contains AI-driven generative UI applications wi
 External and automated agents should also read:
 
 - [`../docs/agent-tech-guide.md`](../docs/agent-tech-guide.md) — lean-ctx, skills, MCP, changelog workflow
-- [`../docs/inbox-pipeline/README.md`](../docs/inbox-pipeline/README.md) — **Inbox → Knowledge pipeline** (architecture, feature taxonomy, all scripts + DB + workflows)
 - [`../CHANGELOG.md`](../CHANGELOG.md) — append under `[Unreleased]` per Agent Update Protocol
-- [`docs/inbox/README.md`](docs/inbox/README.md) — Inbox funnel guide + agent capture protocol
 
 ## Monorepo Structure
 

--- a/GenerativeUI_monorepo/apps/agent-server/tests/test_health.py
+++ b/GenerativeUI_monorepo/apps/agent-server/tests/test_health.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from src.main import app
+
+client = TestClient(app)
+
+
+def test_root_returns_ok() -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json()["message"] == "Agent Server API"
+
+
+def test_health_endpoint() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"

--- a/docs/agent-index.md
+++ b/docs/agent-index.md
@@ -1,0 +1,189 @@
+# Agent Index — Monorepo_ModMe
+
+Single onboarding map for Cursor agents, cloud agents, and Copilot. Run `/init` first, then use this index to navigate the dual-monorepo.
+
+## Read order
+
+1. [`AGENTS.md`](../AGENTS.md) — commands, layout, session end
+2. This file — stack map, ports, skills, drift register
+3. [`docs/agent-tech-guide.md`](agent-tech-guide.md) — lean-ctx, CI, changelog
+4. [`docs/codebase/STACK.md`](codebase/STACK.md) — dependency scorecard
+
+---
+
+## Repository map
+
+| Path | Role | Package manager |
+|------|------|-----------------|
+| `next-forge/` | **Primary** product stack (apps, docs, workshop) | Bun |
+| `GenerativeUI_monorepo/` | **Legacy** agent stack (CopilotKit + agent-server) | Yarn 3.3 |
+| `GenerativeUI_monorepo/UniversalWorkbench*/` | Separate product — **read-only** unless tasked | Yarn 4.10 |
+| Root | Orchestration scripts only | Yarn 3.3 |
+
+### Root commands (`package.json`)
+
+| Command | Stack |
+|---------|-------|
+| `yarn dev:forge` / `:core` / `:workshop` / `:supabase` | next-forge |
+| `yarn dev:generative` | GenerativeUI |
+| `yarn check:forge` / `yarn verify:forge` | next-forge CI parity |
+| `yarn verify:generative` | GenerativeUI CI parity |
+| `yarn pre-commit:check` | Staged-aware hook checks |
+| `.\scripts\new-agent-worktree.ps1` | Isolated feature worktrees |
+
+### Codebase deep docs (`docs/codebase/`)
+
+| File | Use when |
+|------|----------|
+| `STACK.md` | Ports, package managers, setup status |
+| `ARCHITECTURE.md` | GenerativeCanvas, agent-server boundaries |
+| `STRUCTURE.md` | web-dashboard → apps/app mapping |
+| `CONVENTIONS.md` | Naming, imports |
+| `INTEGRATIONS.md` | External services |
+| `CONCERNS.md` | Tech debt, risks |
+| `TESTING.md` | Test frameworks and commands |
+
+---
+
+## next-forge (primary)
+
+Setup: [`next-forge/SETUP.md`](../next-forge/SETUP.md). Skill: [`.agents/skills/next-forge/SKILL.md`](../.agents/skills/next-forge/SKILL.md).
+
+| App | Port | Path | Purpose |
+|-----|------|------|---------|
+| app | 3100 | `next-forge/apps/app` | Authenticated SaaS (Auth.js, Prisma, Liveblocks) |
+| web | 3101 | `next-forge/apps/web` | Marketing site (i18n, CMS) |
+| api | 3102 | `next-forge/apps/api` | Webhooks, cron, health |
+| email | 3103 | `next-forge/apps/email` | React Email preview |
+| docs | 3104 | `next-forge/apps/docs` | Mintlify documentation |
+| storybook | 6106 | `next-forge/apps/storybook` | Design-system workshop (migration target) |
+| agent | 3105 | `next-forge/apps/agent` | VoltAgent experimental server |
+| studio | 3005 | `next-forge/apps/studio` | Prisma Studio GUI |
+
+### Key `@repo/*` packages
+
+`auth`, `database`, `design-system`, `schemas`, `analytics`, `observability`, `security`, `payments`, `email`, `cms`, `collaboration`, `feature-flags`, `internationalization`, `ai`, `webhooks`, `storage`, `seo`, `notifications`, `rate-limit`, `next-config`, `typescript-config`
+
+Local dev:
+
+```powershell
+yarn dev:forge:supabase   # Docker Supabase (Postgres :54322)
+cd next-forge && bun install && bun run db:push
+yarn dev:forge:core         # app + web + api
+```
+
+Sign in: `dev@modme.local` / `devpassword`
+
+---
+
+## GenerativeUI (legacy)
+
+Skill: [`.agents/skills/modme-generative-ui-migrate/SKILL.md`](../.agents/skills/modme-generative-ui-migrate/SKILL.md).
+
+| App / package | Port | Migration role |
+|---------------|------|----------------|
+| web-dashboard | 3001 | **Migrate** → `next-forge/apps/app` |
+| agent-server | 8000 | **Keep** as Python satellite (WebSocket) |
+| shared-schemas | — | **Migrated** → `@repo/schemas` |
+| vibe-web-app | 3000 | Legacy-only (design sandbox) |
+| example-next / example-react | 3002 / 3003 | Legacy-only (templates) |
+| agent-generator | — | Legacy-only (MCP CLI tooling) |
+
+Local dev:
+
+```powershell
+cd GenerativeUI_monorepo && yarn install
+cd apps/agent-server && poetry install
+yarn dev:generative   # from repo root
+```
+
+**Boundaries:** No `workspace:*` imports between monorepos. Integration via HTTP/WebSocket only.
+
+---
+
+## Migration status (GenerativeUI → next-forge)
+
+| Phase | Status | Deliverable |
+|-------|--------|-------------|
+| 1 Workshop | In progress | `next-forge/apps/storybook/stories/modme-workshop.stories.tsx` |
+| 2 Schemas | Done | `next-forge/packages/schemas` (`@repo/schemas`) |
+| 3 Client island | Done | `next-forge/apps/app/app/(authenticated)/generative-ui/` |
+| 4 Cutover | Pending | Feature flags, deprecate web-dashboard |
+
+Rollback: `yarn dev:generative` restores legacy stack; disable feature flags in next-forge.
+
+---
+
+## Agent tooling layer
+
+| Layer | Location |
+|-------|----------|
+| Onboarding command | `.cursor/commands/init.md` |
+| Rules | `.cursor/rules/` — lean-ctx, monorepo-boundaries, multi-agent-worktrees, package-manager-scope |
+| Repo skills | `.agents/skills/` (17 skills — see table below) |
+| Cursor skills | `.cursor/skills/` (80+ vendor/project skills) |
+| CI orchestrator | `scripts/pre-commit-checks.mjs` |
+| Forge CI parity | `scripts/verify-forge-ci.ps1` |
+| Generative CI parity | `scripts/verify-generative-ci.ps1` |
+| Worktrees | `docs/multi-agent-worktrees.md` — **mandatory for feature work** |
+| Beads | `docs/beads-workflow.md` — issue tracking (`modme` prefix) |
+| Debug | `docs/debug-launch-guide.md`, `.vscode/launch.json`, `scripts/launch-manifest.json` |
+| Buildkite | `docs/buildkite-guide.md`, `.buildkite/pipeline.yml` (GenerativeUI) |
+
+### Repo-local skills (`.agents/skills/`)
+
+| Skill | Use when |
+|-------|----------|
+| `next-forge` | Bun dev, ports, Supabase, verify commands |
+| `modme-generative-ui-migrate` | Porting GenerativeCanvas, schemas, client island |
+| `framework-migration-code-migrate` | Wrapper → modme-generative-ui-migrate |
+| `cicd-automation-workflow-automate` | CI/CD pipeline design and consolidation |
+| `smart-git-automation` | Worktree session end, PR to `dev` |
+| `github-actions-efficiency` | Reduce CI minutes, dedupe workflows |
+| `acquire-codebase-knowledge` | Architecture mapping |
+| `create-agentsmd` | AGENTS.md generation |
+| `quality-playbook` | Spec-traced audits |
+| `doublecheck` | Verify agent claims |
+| `supabase` / `supabase-postgres-best-practices` | Database guidance |
+| `voltagent-*` / `create-voltagent` | VoltAgent workflows |
+| `react18-dep-compatibility` | React 18 compat during migration |
+| `memory-merger` | Memory tooling |
+
+---
+
+## CI/CD summary
+
+| Workflow | Scope |
+|----------|-------|
+| `.github/workflows/ci.yml` | Path-filtered GenerativeUI + next-forge + agent-server |
+| `.github/workflows/pre-commit-check.yml` | Policy checks (secret, changelog, launch-json, skills) |
+| `.github/workflows/changelog-check.yml` | PR changelog require-update |
+| `.github/workflows/launch-json-check.yml` | launch.json ↔ manifest sync |
+| `.github/workflows/agenttrace-ci.yml` | Agent session anomalies (`main`, `dev`) |
+| `.buildkite/pipeline.yml` | GenerativeUI lint/test/build |
+
+Local parity: `yarn verify:forge`, `yarn verify:generative`, `yarn pre-commit:check`
+
+---
+
+## Known drift register
+
+Track and resolve these during onboarding maintenance:
+
+| Item | Status |
+|------|--------|
+| next-forge launch.json configs | Added (forge-app/web/api/docs/storybook) |
+| `monorepo-modme.mdc` primary stack wording | Updated → next-forge primary |
+| `apps/studio` wrong `packages/db/` path | Open |
+| CHANGELOG `[Unreleased]` bucket hygiene | Updated |
+| Beads issue tracking | Initialized (`modme` prefix); run `yarn beads:init` on fresh clones |
+
+---
+
+## Session end checklist
+
+1. Append `CHANGELOG.md` under `[Unreleased]` if change is notable
+2. Update this index or `AGENTS.md` if layout/commands changed
+3. Run `yarn pre-commit:check` before commit
+4. In worktrees: `yarn verify:forge` or `yarn verify:generative` as appropriate
+5. `.\scripts\vibe-session-finish.ps1` — commit, push, PR to **`dev`**

--- a/docs/agent-tech-guide.md
+++ b/docs/agent-tech-guide.md
@@ -4,7 +4,7 @@ Canonical reference for **AI agents** and **humans** working in this repository:
 
 | Audience | Start here |
 |----------|------------|
-| New agent session | `/init` in Cursor â†’ `AGENTS.md` â†’ this guide â†’ `CHANGELOG.md` (Agent Update Protocol) |
+| New agent session | `/init` in Cursor → `AGENTS.md` → [`docs/agent-index.md`](./agent-index.md) → this guide → `CHANGELOG.md` (Agent Update Protocol) |
 | Human contributor | `/init`, `AGENTS.md`, `docs/debug-launch-guide.md`, `scripts/cursor-ai/README.md` |
 | CI / cloud agent | `CHANGELOG.md` (protocol), `scripts/validate-changelog.mjs`, `.github/workflows/changelog-check.yml` |
 | Local debugging | `docs/debug-launch-guide.md`, `.vscode/launch.json`, `scripts/validate-launch-json.mjs` |
@@ -231,11 +231,20 @@ Restart Cursor / VS Code after editing MCP config. On Windows Antigravity, use `
 
 | Skill | Use when |
 |-------|----------|
+| `next-forge` | Bun dev, ModMe ports, Supabase, verify commands |
+| `modme-generative-ui-migrate` | GenerativeUI → next-forge migration phases |
+| `framework-migration-code-migrate` | Router to modme-generative-ui-migrate |
+| `cicd-automation-workflow-automate` | CI/CD pipeline design and consolidation |
+| `smart-git-automation` | Worktree session end, PR to `dev` |
 | `create-agentsmd` | Generate or refresh `AGENTS.md` |
 | `acquire-codebase-knowledge` | Map architecture, onboarding docs |
 | `quality-playbook` | Spec-traced audits, defect hunting |
 | `github-actions-efficiency` | CI cost/efficiency review |
 | `doublecheck` | Verify agent claims with sources |
+| `supabase` / `supabase-postgres-best-practices` | Database guidance |
+| `voltagent-*` / `create-voltagent` | VoltAgent workflows |
+| `react18-dep-compatibility` | React 18 compat during migration |
+| `memory-merger` | Memory tooling |
 
 ### Global (`~/.agents/skills/`) â€” installed for this initiative
 

--- a/docs/beads-workflow.md
+++ b/docs/beads-workflow.md
@@ -1,0 +1,45 @@
+# Beads issue tracking — Monorepo_ModMe
+
+Git-backed task memory for multi-session agent work. Prefix: **`modme`**.
+
+## Initialize (once)
+
+```powershell
+yarn beads:init
+# or: powershell -ExecutionPolicy Bypass -File ./scripts/init-beads-starter-issues.ps1
+```
+
+Uses `npx @beads/bd` (no global install). Idempotent — skips init/seed if `.beads/` or issues already exist.
+
+Manual alternative:
+
+```powershell
+npx @beads/bd init --prefix modme --non-interactive --skip-agents
+```
+
+If beads MCP is enabled in Cursor, run `/init` Phase 1 or use the beads MCP `init` tool with prefix `modme`.
+
+## Starter issues (create after init)
+
+| ID | Title | Type |
+|----|-------|------|
+| modme-1 | chore: Verify compound Full Stack: Forge Core + Agent Server | chore |
+| modme-2 | chore: CI Phase A — confirm pre-commit vs ci.yml split | chore |
+| modme-3 | task: Migration Phase 4 — feature-flag cutover for generative-ui | task |
+| modme-4 | chore: Document yarn verify:forge + yarn verify:generative in onboarding | chore |
+| modme-5 | task: Complete Storybook workshop parity with GenerativeCanvas | task |
+
+## When to use beads vs chat todos
+
+- **Beads:** multi-session work, dependencies, survives context compaction
+- **Chat todos:** single-session linear tasks
+
+See [`docs/agent-index.md`](agent-index.md) and [`.cursor/commands/init.md`](../.cursor/commands/init.md).
+
+## CI / automation integration
+
+Onboarding and CI work should be tracked in beads when it spans sessions. Use the repo-local skill:
+
+- [`.agents/skills/cicd-automation-workflow-automate/SKILL.md`](../.agents/skills/cicd-automation-workflow-automate/SKILL.md) — Phase E (beads + verify scripts)
+
+After `yarn beads:init`, agents run `npx @beads/bd ready` at session start and close issues when CI/migration tasks complete.

--- a/docs/debug-launch-guide.md
+++ b/docs/debug-launch-guide.md
@@ -65,8 +65,9 @@ Jest configs use `yarn jest --runInBand` on the **current file** in each package
 
 ### Compounds
 
-- **Full Stack: Agent Server + Web Dashboard** — backend + Next UI
-- **Full Stack: Agent Server + Vibe Web App** — backend + Vite playground
+- **Full Stack: Forge Core + Agent Server** — next-forge App (3100) + Web (3101) + API (3102) + Agent Server (8000)
+- **Full Stack: Agent Server + Web Dashboard** — backend + Next UI (legacy)
+- **Full Stack: Agent Server + Vibe Web App** — backend + Vite playground (legacy)
 
 ### Utility
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "check:forge": "powershell -ExecutionPolicy Bypass -File ./scripts/run-forge-bun.ps1 run check",
     "fix:forge": "powershell -ExecutionPolicy Bypass -File ./scripts/run-forge-bun.ps1 run fix",
     "verify:forge": "powershell -ExecutionPolicy Bypass -File ./scripts/verify-forge-ci.ps1",
+    "verify:generative": "powershell -ExecutionPolicy Bypass -File ./scripts/verify-generative-ci.ps1",
+    "beads:init": "powershell -ExecutionPolicy Bypass -File ./scripts/init-beads-starter-issues.ps1",
     "pre-commit:check": "node scripts/pre-commit-checks.mjs",
     "hooks:install": "powershell -ExecutionPolicy Bypass -File ./scripts/install-git-hooks.ps1"
   }

--- a/scripts/init-beads-starter-issues.ps1
+++ b/scripts/init-beads-starter-issues.ps1
@@ -1,0 +1,64 @@
+# Initialize beads (modme prefix) and seed starter issues from docs/beads-workflow.md
+# Uses npx @beads/bd — no global install required.
+# Pair with .agents/skills/cicd-automation-workflow-automate/SKILL.md (Phase E).
+
+param(
+  [string]$Prefix = "modme",
+  [switch]$SkipIssues
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$RepoRoot = Split-Path -Parent $ScriptDir
+
+Push-Location $RepoRoot
+try {
+  $bd = "npx"
+  $bdArgs = @("--yes", "@beads/bd")
+
+  $beadsDir = Join-Path $RepoRoot ".beads"
+  if (-not (Test-Path $beadsDir)) {
+    Write-Host "Initializing beads (prefix: $Prefix)..." -ForegroundColor Cyan
+    & $bd @bdArgs init --prefix $Prefix --non-interactive --skip-agents
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  }
+  else {
+    Write-Host "Beads already initialized at .beads/" -ForegroundColor Yellow
+  }
+
+  if ($SkipIssues) {
+    Write-Host "Skipping starter issue creation (--SkipIssues)." -ForegroundColor Yellow
+    exit 0
+  }
+
+  $statsJson = & $bd @bdArgs stats --json 2>$null
+  if ($LASTEXITCODE -eq 0 -and $statsJson) {
+    $stats = $statsJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+    if ($stats -and $stats.total -gt 0) {
+      Write-Host "Starter issues already exist ($($stats.total) total). Skipping seed." -ForegroundColor Yellow
+      exit 0
+    }
+  }
+
+  Write-Host "Creating starter issues..." -ForegroundColor Cyan
+
+  $issues = @(
+    @{ Title = "chore: Verify compound Full Stack: Forge Core + Agent Server"; Type = "chore" },
+    @{ Title = "chore: CI Phase A - confirm pre-commit vs ci.yml split"; Type = "chore" },
+    @{ Title = "task: Migration Phase 4 - feature-flag cutover for generative-ui"; Type = "task" },
+    @{ Title = "chore: Document yarn verify:forge + yarn verify:generative in onboarding"; Type = "chore" },
+    @{ Title = "task: Complete Storybook workshop parity with GenerativeCanvas"; Type = "task" }
+  )
+
+  foreach ($issue in $issues) {
+    & $bd @bdArgs create $issue.Title -t $issue.Type --silent
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    Write-Host "  + $($issue.Title)" -ForegroundColor Green
+  }
+
+  Write-Host "Beads ready. Run: npx @beads/bd ready" -ForegroundColor Green
+}
+finally {
+  Pop-Location
+}

--- a/scripts/launch-manifest.json
+++ b/scripts/launch-manifest.json
@@ -94,7 +94,12 @@
     "Agent Server (FastAPI)",
     "Agent Generator: build + current test",
     "Example Next: dev server",
-    "Example React: dev server"
+    "Example React: dev server",
+    "next-forge App (SaaS)",
+    "next-forge Web (Marketing)",
+    "next-forge API",
+    "next-forge Docs (Mintlify)",
+    "next-forge Storybook (Workshop)"
   ],
   "requiredTasks": ["vibe-web-app: dev", "agent-generator: build"],
   "requiredCompounds": [

--- a/scripts/pre-commit-checks.mjs
+++ b/scripts/pre-commit-checks.mjs
@@ -132,15 +132,10 @@ function runForgeCheckIfNeeded(files) {
 }
 
 function runForgeCiSuite(files) {
-  if (!files.some((f) => f.startsWith(FORGE_PREFIX))) {
-    return;
+  // Stack builds run in ci.yml only; pre-commit CI runs policy checks.
+  if (files.some((f) => f.startsWith(FORGE_PREFIX))) {
+    ok("next-forge build suite deferred to ci.yml (policy checks only here)");
   }
-
-  ok("running next-forge CI suite (check, test, build)");
-  runForgeBun(["run", "check"]);
-  runForgeBun(["run", "test"]);
-  runForgeBun(["run", "build"]);
-  ok("next-forge CI suite passed");
 }
 
 function main() {

--- a/scripts/verify-generative-ci.ps1
+++ b/scripts/verify-generative-ci.ps1
@@ -1,0 +1,43 @@
+# CI-parity verification for GenerativeUI_monorepo (manual pre-PR / agent verify)
+param(
+  [switch]$SkipLint,
+  [switch]$SkipTest,
+  [switch]$SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Split-Path -Parent $ScriptDir
+$GenRoot = Join-Path $RepoRoot "GenerativeUI_monorepo"
+
+Write-Host "== GenerativeUI CI parity verify ==" -ForegroundColor Cyan
+
+if (-not (Test-Path $GenRoot)) {
+  Write-Error "Missing directory: $GenRoot"
+}
+
+Push-Location $GenRoot
+try {
+  if (-not $SkipLint) {
+    Write-Host "1/3 yarn lint..." -ForegroundColor Cyan
+    yarn lint
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  }
+
+  if (-not $SkipTest) {
+    Write-Host "2/3 yarn test..." -ForegroundColor Cyan
+    yarn test
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  }
+
+  if (-not $SkipBuild) {
+    Write-Host "3/3 yarn build..." -ForegroundColor Cyan
+    yarn build
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+  }
+}
+finally {
+  Pop-Location
+}
+
+Write-Host "OK - GenerativeUI CI parity checks passed" -ForegroundColor Green


### PR DESCRIPTION
## Summary

- Onboarding delta: agent index, beads (yarn beads:init), verify:generative, cicd-automation Phase E, CI/pre-commit refinements, agent-server health test
- Includes chore/agent-tooling-and-ci commits (inbox pipeline foundation, next-forge CI, worktree tooling)

## Note on main

This branch diverged from origin/main before Copilot PR #71. Direct PR to main is blocked by unrelated histories. Merge to dev first, then integrate dev→main separately.

## Duplicate local copies

Main checkout (Monorepo_ModMe on chore/agent-tooling-and-ci) has uncommitted copies of overlapping files — safe for Copilot worktree; discard after merge.

## Test plan

- [ ] CI workflows pass
- [ ] yarn beads:init idempotent

@copilot Please review for CI/onboarding correctness.

Made with [Cursor](https://cursor.com)