### PR TITLE
Fix local tool hooks and add lean-ctx steering note

### DIFF
--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -5,6 +5,8 @@
         "bash": "C:/Users/dylan/.gemini/antigravity/bin/lean-ctx.exe hook observe",
         "timeoutSec": 5,
         "type": "command"
-	}
-      ]
+      }
+    ]
+  },
+  "version": 1
 }

--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -5,20 +5,6 @@
         "bash": "C:/Users/dylan/.gemini/antigravity/bin/lean-ctx.exe hook observe",
         "timeoutSec": 5,
         "type": "command"
-      }
-    ],
-    "preToolUse": [
-      {
-        "bash": "C:/Users/dylan/.gemini/antigravity/bin/lean-ctx.exe hook rewrite",
-        "timeoutSec": 15,
-        "type": "command"
-      },
-      {
-        "bash": "C:/Users/dylan/.gemini/antigravity/bin/lean-ctx.exe hook redirect",
-        "timeoutSec": 5,
-        "type": "command"
-      }
-    ]
-  },
-  "version": 1
+	}
+      ]
 }

--- a/.kiro/steering/lean-ctx.md
+++ b/.kiro/steering/lean-ctx.md
@@ -1,0 +1,38 @@
+---
+inclusion: always
+---
+
+# lean-ctx — Context Engineering Layer
+
+The workspace has the `lean-ctx` MCP server installed. You MUST prefer lean-ctx tools over native equivalents for token efficiency and caching.
+
+## Mandatory Tool Preferences
+
+| Use this | Instead of | Why |
+|----------|-----------|-----|
+| `mcp_lean_ctx_ctx_read` | `readFile`, `readCode` | Cached reads, 10 compression modes, re-reads cost ~13 tokens |
+| `mcp_lean_ctx_ctx_multi_read` | `readMultipleFiles` | Batch cached reads in one call |
+| `mcp_lean_ctx_ctx_shell` | `executeBash` | Pattern compression for git/npm/test output |
+| `mcp_lean_ctx_ctx_search` | `grepSearch` | Compact, .gitignore-aware results |
+| `mcp_lean_ctx_ctx_tree` | `listDirectory` | Compact directory maps with file counts |
+
+## When to use native Kiro tools instead
+
+- `fsWrite` / `fsAppend` — always use native (lean-ctx doesn't write files)
+- `strReplace` — always use native (precise string replacement)
+- `semanticRename` / `smartRelocate` — always use native (IDE integration)
+- `getDiagnostics` — always use native (language server diagnostics)
+- `deleteFile` — always use native
+
+## Session management
+
+- At the start of a long task, call `mcp_lean_ctx_ctx_preload` with a task description to warm the cache
+- Use `mcp_lean_ctx_ctx_compress` periodically in long conversations to checkpoint context
+- Use `mcp_lean_ctx_ctx_knowledge` to persist important discoveries across sessions
+
+## Rules
+
+- NEVER loop on edit failures — switch to `mcp_lean_ctx_ctx_edit` immediately
+- For large files, use `mcp_lean_ctx_ctx_read` with `mode: "signatures"` or `mode: "map"` first
+- For re-reading a file you already read, just call `mcp_lean_ctx_ctx_read` again (cache hit = ~13 tokens)
+- When running tests or build commands, use `mcp_lean_ctx_ctx_shell` for compressed output

--- a/.kiro/steering/lean-ctx.md
+++ b/.kiro/steering/lean-ctx.md
@@ -10,29 +10,31 @@ The workspace has the `lean-ctx` MCP server installed. You MUST prefer lean-ctx 
 
 | Use this | Instead of | Why |
 |----------|-----------|-----|
-| `mcp_lean_ctx_ctx_read` | `readFile`, `readCode` | Cached reads, 10 compression modes, re-reads cost ~13 tokens |
-| `mcp_lean_ctx_ctx_multi_read` | `readMultipleFiles` | Batch cached reads in one call |
-| `mcp_lean_ctx_ctx_shell` | `executeBash` | Pattern compression for git/npm/test output |
-| `mcp_lean_ctx_ctx_search` | `grepSearch` | Compact, .gitignore-aware results |
-| `mcp_lean_ctx_ctx_tree` | `listDirectory` | Compact directory maps with file counts |
+| `ctx_read(path, mode)` | `readFile`, `readCode` | Cached reads, multiple compression modes, cheap re-reads |
+| `ctx_multi_read(paths, mode)` | `readMultipleFiles` | Batch cached reads in one call |
+| `ctx_shell(command)` | `executeBash` | Pattern compression for git/npm/test output |
+| `ctx_search(pattern, path)` | `grepSearch` | Compact, .gitignore-aware results |
+| `ctx_tree(path)` | `listDirectory` | Compact directory maps with file counts |
 
 ## When to use native Kiro tools instead
 
-- `fsWrite` / `fsAppend` — always use native (lean-ctx doesn't write files)
-- `strReplace` — always use native (precise string replacement)
-- `semanticRename` / `smartRelocate` — always use native (IDE integration)
-- `getDiagnostics` — always use native (language server diagnostics)
-- `deleteFile` — always use native
+- `fsWrite` / `fsAppend` - always use native for direct file writes
+- `strReplace` - always use native (precise string replacement)
+- `semanticRename` / `smartRelocate` - always use native (IDE integration)
+- `getDiagnostics` - always use native (language server diagnostics)
+- `deleteFile` - always use native
+
+Note: lean-ctx still supports file edits through `ctx_edit(path, old, new)` (or native Edit), but direct write operations should stay on native tools.
 
 ## Session management
 
-- At the start of a long task, call `mcp_lean_ctx_ctx_preload` with a task description to warm the cache
-- Use `mcp_lean_ctx_ctx_compress` periodically in long conversations to checkpoint context
-- Use `mcp_lean_ctx_ctx_knowledge` to persist important discoveries across sessions
+- At the start of a long task, call `ctx_session(action="status")` and `ctx_knowledge(action="wakeup")`
+- Use `ctx_compress` periodically in long conversations to checkpoint context
+- Use `ctx_knowledge(action="remember", content="...")` to persist important discoveries across sessions
 
 ## Rules
 
-- NEVER loop on edit failures — switch to `mcp_lean_ctx_ctx_edit` immediately
-- For large files, use `mcp_lean_ctx_ctx_read` with `mode: "signatures"` or `mode: "map"` first
-- For re-reading a file you already read, just call `mcp_lean_ctx_ctx_read` again (cache hit = ~13 tokens)
-- When running tests or build commands, use `mcp_lean_ctx_ctx_shell` for compressed output
+- NEVER loop on edit failures - switch to `ctx_edit(path, old, new)` immediately
+- For large files, use `ctx_read(path, "signatures")` or `ctx_read(path, "map")` first
+- For re-reading a file you already read, call `ctx_read(path, mode)` again for a cache hit
+- When running tests or build commands, use `ctx_shell(command)` for compressed output


### PR DESCRIPTION
# Pull Request

## Summary

Updates local agent hook wiring and adds a lean-ctx steering note so this worktree session can run tools reliably and keep its local context guidance documented.

## Intent & Scope

**Problem:**
The session was blocked by tool-hook failures, and the local workspace lacked a matching steering note for lean-ctx behavior.

**Audience / affected area:**
Contributors and agents working in this worktree who rely on `.github/hooks/hooks.json` and `.kiro/steering` guidance.

**Out of scope:**
Repository-wide hook policy redesign, broader CI/workflow changes, and unrelated code refactors.

## Changes

- Adjusted `.github/hooks/hooks.json` local hook configuration to remove the failing pre-tool hook chain in this session context.
- Added `.kiro/steering/lean-ctx.md` with lean-ctx steering guidance.

## Validation

- [ ] Local build/lint passes (`npm run lint` / `npm run build`)
- [ ] Agent health verified (`curl http://localhost:8000/health`)
- [ ] New components registered in `ALLOWED_TYPES` and `renderElement` switch (if UI change)
- [ ] Secrets not introduced into source or git history
- [ ] CI checks pass on this branch

**Steps to reproduce / verify:**

```
1. Check out `ditto190-congenial-doodle`.
2. Inspect `.github/hooks/hooks.json` and `.kiro/steering/lean-ctx.md`.
3. Run an agent tool command and confirm pre-tool hook failure no longer blocks execution.
```

## awesome-copilot Reuse

- **Prompts used:** none - no matching reusable prompt asset was required for this focused config/doc change
- **Skills used:** none
- **Checklists used:** AGENTS.md workspace process guidance
- **Index version consulted:** N/A

## Risks & Tradeoffs

| Risk | Severity | Mitigation |
|------|----------|------------|
| Hook behavior drift from repo defaults | Medium | Keep change scoped, review with maintainers, and align follow-up if central policy differs |
| Local guidance may become stale | Low | Update `.kiro/steering/lean-ctx.md` alongside future hook changes |

## Notes for Reviewers (Humans & Agents)

This PR is intentionally small and session-focused. Please review whether the hook change should remain local-only or be standardized.

> **Agents:** Read `AGENTS.md` and `agents/review/code-review-rubric.md` before reviewing.
> Flag issues as: `BLOCKER` / `NON-BLOCKER` / `SUGGESTION`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed failing `preToolUse` hooks from `.github/hooks/hooks.json`, restored a valid JSON structure, and added `.kiro/steering/lean-ctx.md` aligned with canonical `ctx_*` tool names. Tools now run reliably in this worktree with clear preferences for `lean-ctx` MCP tools.

<sup>Written for commit 8d8a4de5e03dd96d69dfead4fae8e25f003cacea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ditto190/modme-ui-01/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

