### PR TITLE
docs(repo): thermo-nuclear Round 2 redundancy review synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ CI runs `node scripts/validate-changelog.mjs` on pull requests. See `docs/agent-
 - (cursor) Cursor marketplace plugin skills under `.cursor/skills/` — thermos, fix-ci, orchestrate, principle-\*, voltagent, and related agent workflows
 - (copilot) Expanded root `.github/copilot-instructions.md` for dual-monorepo (next-forge + GenerativeUI) commands and verification workflow
 - (cursor) Additional Claude plugin enables in `.cursor/settings.json` (commit-commands, supabase, typescript-lsp, rust-analyzer-lsp, agent-sdk-dev)
+- (repo) Dual monorepo audit — ECL harness (`harness/`, `yarn lint:harness`), `stack-paths.json`, C4 product docs, refreshed `docs/codebase/*`, schema contract tests, migration phase4 notes
+- (repo) Thermo-nuclear workflow — `thermo-nuclear-monorepo-review` skill, `modme-migration-review` collection, molecule-index orchestrator, ADR-0012 bounded-parallel lifecycle
+- (repo) `yarn molecule-index:verify` + `molecule-contract` CI job; PORTING_GUIDE ECL slices in `docs/migration/porting-guide-slices.md`
+- (repo) Thermo-nuclear Round 2 redundancy review — `CONTEXT.md`, synthesis report, wave-2 manifest, archived ECL change `thermo-round2-redundancy`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ CI runs `node scripts/validate-changelog.mjs` on pull requests. See `docs/agent-
 
 ### Fixed
 
+- (docs) Thermo Round 2 archive STATUS/links/manifest count alignment (PR #90)
 - (dev) `init-worktrees.ps1` — use `$LASTEXITCODE` for git branch detection; disable direnv during setup (no spurious `direnv: error` / `branch already exists`)
 - (dev) `new-agent-worktree.ps1` — usage help when `-Name` omitted; `DIRENV_DISABLE` during creation; default `-Owner cursor`
 - (vscode) Set `git.path` in `.vscode/settings.json` so Cursor Agent Review finds Git on Windows when it is not on PATH

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,39 @@
+# CONTEXT.md — ModMe Domain Glossary
+
+Vocabulary for architecture reviews, ECL changes, and agent onboarding. Use these terms in ADRs and deepening proposals.
+
+## DualMonorepo
+
+Independent package-manager roots (`next-forge/` Bun, `GenerativeUI_monorepo/` Yarn) orchestrated from repo root. Integration via HTTP/WebSocket and golden Zod schemas only — never `workspace:*` across stacks.
+
+## GenUIIsland
+
+Client-only route group in `next-forge/apps/app` (`(authenticated)/generative-ui/`) that renders agent-driven UI via WebSocket to the AgentSatellite. Server Components shell; `'use client'` leaf for canvas + hooks.
+
+## AgentSatellite
+
+Python FastAPI + AG2 runtime at `GenerativeUI_monorepo/apps/agent-server`. Hexagonal layout: thin WebSocket adapter, `GroupChatAdapter`, Pydantic models mirroring `@repo/schemas`.
+
+## MoleculeIndex
+
+Unified indexing spine (`yarn molecule-index`) for AST chunks, Zod modules, MCP molecules, and toolset entries. Manifest at `data/molecule-index/manifest.json`; branded IDs in `@repo/schemas`.
+
+## IntakePipeline
+
+Root Supabase pgvector inbox path: `scripts/intake-orchestrator.mjs` → `inbox-*.mjs` → promote/embed. Distinct from legacy GenerativeUI `intake-pipeline/` (Copilot telemetry).
+
+## LegacyRootStub
+
+Deprecated `src/` (Next.js GenUI) + `agent/` (Python ADK + vendored genai-toolbox). Canonical owners: next-forge app + agent-server. Archive per Phase 4 — do not extend.
+
+## SchemaContract
+
+Golden JSON fixture (`genui-agent-contract.golden.json`) enforced by Vitest (`@repo/schemas`) and pytest (`test_schemas_contract.py`). Single wire contract; manual Pydantic sync until codegen exists.
+
+## WorkshopLayer
+
+Storybook `ModMe/Workshop` stories in `next-forge/apps/storybook` — Phase 1 migration mirror before production GenUIIsland parity.
+
+## SkillRegistry
+
+Three tiers: `.agents/skills/` (repo canonical), `.cursor/skills/` (Cursor + vendor), `.vendor/awesome-copilot-main/`. Precedence: local override > `.agents` > `.cursor` > vendor.

--- a/data/molecule-index/manifest.json
+++ b/data/molecule-index/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-06-28T07:44:48.601Z",
+  "generated_at": "2026-07-04T10:06:38.981Z",
   "stack": "forge",
   "schema_version": "1.0.0",
   "record_kinds": [
@@ -102,7 +102,7 @@
       "semver": "1.0.0",
       "zod_export": null,
       "greptime_id": null,
-      "route_hint": "audit"
+      "route_hint": "dashboard"
     },
     {
       "kind": "zod_module",
@@ -111,7 +111,7 @@
       "semver": "1.0.0",
       "zod_export": null,
       "greptime_id": null,
-      "route_hint": "audit"
+      "route_hint": "dashboard"
     },
     {
       "kind": "zod_module",
@@ -120,7 +120,7 @@
       "semver": "1.0.0",
       "zod_export": null,
       "greptime_id": null,
-      "route_hint": "audit"
+      "route_hint": "dashboard"
     },
     {
       "kind": "zod_module",
@@ -129,7 +129,7 @@
       "semver": "1.0.0",
       "zod_export": null,
       "greptime_id": null,
-      "route_hint": "audit"
+      "route_hint": "dashboard"
     },
     {
       "kind": "zod_module",
@@ -138,7 +138,7 @@
       "semver": "1.0.0",
       "zod_export": null,
       "greptime_id": null,
-      "route_hint": "audit"
+      "route_hint": "dashboard"
     }
   ],
   "source_only": true,

--- a/docs/codebase/CONCERNS.md
+++ b/docs/codebase/CONCERNS.md
@@ -6,14 +6,15 @@
 
 **High-churn files (last 90 days, from scan):**
 
-| Churn | Path                                                        | Signal                           |
-| ----: | ----------------------------------------------------------- | -------------------------------- |
-|    13 | `CHANGELOG.md`                                              | Release/doc churn                |
-|    10 | `.gitignore`                                                | Tooling/vendor growth            |
-|     7 | `package.json`, `.vscode/settings.json`, `AGENTS.md`        | Agent/orchestration config drift |
-|     6 | `docs/agent-tech-guide.md`                                  | Living agent docs                |
-|     5 | `.github/workflows/ci.yml`, `scripts/pre-commit-checks.mjs` | CI consolidation in progress     |
-|     4 | `next-forge/packages/schemas/index.ts`                      | Migration schema touchpoint      |
+| Churn | Path                                                            | Signal                       |
+| ----: | --------------------------------------------------------------- | ---------------------------- |
+|    18 | `CHANGELOG.md`                                                  | Release/doc churn            |
+|    10 | `.gitignore`                                                    | Tooling/vendor growth        |
+|     9 | `.github/workflows/ci.yml`                                      | CI consolidation             |
+|     9 | `docs/agent-tech-guide.md`                                      | Living agent docs            |
+|     8 | `AGENTS.md`                                                     | Agent orchestration drift    |
+|     6 | `GenerativeUI_monorepo/apps/agent-server/src/models/schemas.py` | Contract parity work         |
+|     6 | `scripts/pre-commit-checks.mjs`                                 | Harness + path-filter wiring |
 
 **TODOs/FIXMEs:** Scan surfaces many hits from `.conda/` Python stdlib and vendored content — not application debt. Actionable app TODO example: `knowledge-base.json` embedded MCP registry fetcher (`TODO: Implement in phases`).
 
@@ -22,18 +23,26 @@
 | Risk                           | Detail                                                                                       | Mitigation status                                                                                                                                               |
 | ------------------------------ | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Dual monorepo boundaries**   | Forbidden: `workspace:*` or relative imports across `next-forge/` ↔ `GenerativeUI_monorepo/` | HTTP/WebSocket only; enforced in `AGENTS.md`, `.cursor/rules/monorepo-boundaries.mdc`                                                                           |
+| **Five-way GenUI redundancy**  | Root `src/`, root `agent/`, web-dashboard, forge island, CopilotKit proxy                  | Phase 4 archive + `@repo/genui-client` extraction (Round 2)                                                                                                     |
+| **Dual schema packages**       | `@generative-ui/shared-schemas` (zod v3) vs `@repo/schemas` (zod v4)                         | Unify on forge; retire legacy package                                                                                                                           |
 | **Schema drift TS/Python**     | `@repo/schemas` vs Pydantic — manual sync                                                    | **Mitigated:** golden JSON + Vitest (`schemas.test.ts`) + pytest (`test_schemas_contract.py`); bump process in `next-forge/packages/schemas/README.md`         |
 | **WebSocket state desync**     | GenerativeCanvas depends on agent-server stream                                              | **Mitigated:** `use-agent-state.ts` exponential backoff (max 10, 3–30s), `reconnecting` status, manual `retryConnection`, `visibilitychange` reconnect; Vitest on `reconnect-delay.ts` |
+| **Unauthenticated WS**         | agent-server broadcasts to all sockets                                                       | Per-connection auth (Round 2 security)                                                                                                                          |
+| **Golden JSON merge conflicts**| Duplicate fixtures                                                                           | Single canonical content; validate in CI                                                                                                                          |
 | **Agent orchestration limits** | Multi-agent AG2 + external LLM rate/context limits                                           | Operational monitoring; not code-guarded in repo                                                                                                                |
+| **Worktree yarn deps**         | Fresh worktrees need `yarn install`                                                          | `yarn worktree:doctor:fix`                                                                                                                                      |
+| **Skill registry collisions**  | 4 keys in both `.agents` and `.cursor`                                                       | CI content-hash dedup gate                                                                                                                                      |
 | **Scan performance**           | Full-repo scan traverses `.conda/`, `.vendor/` — slow on Windows                             | Exclude or run from worktree; `.gitignore` does not exclude `.conda` from scan.py `EXCLUDE_DIRS`                                                                |
 
 ### 3) Testing Gaps (migration-critical)
 
-| Gap                           | Evidence                                                                                       |
+| Gap                           | Evidence / status                                                                              |
 | ----------------------------- | ---------------------------------------------------------------------------------------------- |
-| Playwright not in CI          | `.github/workflows/ci.yml` next-forge job runs Vitest only                                     |
+| Playwright not in CI          | `.github/workflows/ci.yml` next-forge job runs Vitest only; full stack documented as local-only |
 | E2E requires manual stack     | `playwright.config.ts` — no `webServer`; ports 3100–3102 + agent 8000                          |
 | Schema parity test missing    | ~~No committed contract test~~ — `@repo/schemas` Vitest + agent-server pytest against golden JSON |
+| Root legacy tests             | No CI job for `src/`/`agent/` — deprecated                                                        |
+| Bun not on PATH (Windows)     | `verify:forge` fails without `bun install` in next-forge                                          |
 | AWT not installed             | No `next-forge/tests/awt/` YAML scenarios                                                      |
 | GenerativeUI legacy test docs | `GenerativeUI_monorepo/README.md` still mentions Cypress/Jest — may not match current packages |
 
@@ -51,3 +60,6 @@
 - `.github/workflows/ci.yml`
 - `.agents/skills/modme-generative-ui-migrate/SKILL.md`
 - `AGENTS.md`
+- `docs/migration/phase4-cutover.md`
+- `docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md` (Round 2 synthesis)
+- `CONTEXT.md` (domain glossary)

--- a/docs/workflows/reports/manifest.json
+++ b/docs/workflows/reports/manifest.json
@@ -1,24 +1,46 @@
 {
-  "wave": 1,
-  "generated_at": "2026-06-28T12:00:00.000Z",
-  "branch": "feature/cursor/thermo-nuclear-workflow-index",
-  "explorers": {
+  "wave": 2,
+  "generated_at": "2026-07-04T10:10:00.000Z",
+  "branch": "feature/cursor/thermo-round2-redundancy",
+  "baseline": "dev",
+  "scope": "thermo-round2-redundancy",
+  "lanes": {
+    "explorer-root": {
+      "status": "complete",
+      "focus_paths": ["src/", "agent/", "harness/", "docs/codebase/"],
+      "findings": "Critical legacy root duplication vs next-forge + agent-server; archive after Phase 4"
+    },
     "explorer-forge": {
       "status": "complete",
       "focus_paths": ["next-forge/apps", "next-forge/packages"],
-      "acquire_docs": ["docs/codebase/ARCHITECTURE.md", "docs/codebase/STRUCTURE.md", "docs/codebase/STACK.md"]
+      "findings": "Phase 2-3 pass; Phase 4 fail (no feature-flag gating); Phase 1 partial"
     },
     "explorer-legacy": {
       "status": "complete",
-      "focus_paths": ["GenerativeUI_monorepo/apps", "src", "agent"],
-      "acquire_docs": ["docs/codebase/INTEGRATIONS.md", "docs/migration/phase4-cutover.md"]
+      "focus_paths": ["GenerativeUI_monorepo/apps", "packages/shared-schemas"],
+      "findings": "Dual schema packages (zod v3 vs v4); GenerativeCanvas/useAgentState duplicated"
     },
-    "contract-auditor": {
+    "explorer-universalworkbench": {
       "status": "complete",
-      "focus_paths": ["next-forge/packages/schemas", "packages/intake-contracts"],
-      "contracts": ["genui-agent-contract.golden.json", "ws-contract.test.ts"]
-    }
+      "focus_paths": ["GenerativeUI_monorepo/UniversalWorkbench/"],
+      "findings": "MCP registry overlap conceptual only; no UI component registry collision with design-system"
+    },
+    "explorer-scripts": {
+      "status": "complete",
+      "focus_paths": ["scripts/", ".github/workflows/", "harness/"],
+      "findings": "Inbox orchestrator vs workflow fan-out drift; dual intake pipelines (inbox vs copilot-telemetry)"
+    },
+    "explorer-skills": {
+      "status": "complete",
+      "focus_paths": [".agents/skills/", ".cursor/skills/", ".vendor/awesome-copilot-main/"],
+      "findings": "4 local skill key collisions; 522 vendor skills; 6 vendor/local key overlaps"
+    },
+    "thermo-security": { "status": "complete", "critical": 2, "high": 2 },
+    "thermo-performance": { "status": "complete", "high": 4, "medium": 3 },
+    "thermo-correctness": { "status": "complete", "critical": 1, "high": 2 },
+    "thermo-readability": { "status": "complete", "code_judo_moves": 8 }
   },
-  "blocked_wave_2_until": "this manifest published",
-  "molecule_manifest": "data/molecule-index/manifest.json"
+  "blocked_wave_2_until": "satisfied — wave 1 published",
+  "molecule_manifest": "data/molecule-index/manifest.json",
+  "synthesis": "docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md"
 }

--- a/docs/workflows/reports/manifest.json
+++ b/docs/workflows/reports/manifest.json
@@ -35,12 +35,12 @@
       "focus_paths": [".agents/skills/", ".cursor/skills/", ".vendor/awesome-copilot-main/"],
       "findings": "4 local skill key collisions; 522 vendor skills; 6 vendor/local key overlaps"
     },
-    "thermo-security": { "status": "complete", "critical": 2, "high": 2 },
-    "thermo-performance": { "status": "complete", "high": 4, "medium": 3 },
+    "thermo-security": { "status": "complete", "critical": 2, "high": 1 },
+    "thermo-performance": { "status": "complete", "high": 2, "medium": 1 },
     "thermo-correctness": { "status": "complete", "critical": 1, "high": 2 },
     "thermo-readability": { "status": "complete", "code_judo_moves": 8 }
   },
-  "blocked_wave_2_until": "satisfied — wave 1 published",
+  "blocked_wave_2_until": "satisfied â€” wave 1 published",
   "molecule_manifest": "data/molecule-index/manifest.json",
   "synthesis": "docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md"
 }

--- a/docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md
+++ b/docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md
@@ -1,0 +1,135 @@
+# Thermo-Nuclear Redundancy Review — Synthesis (Round 2)
+
+**Date:** 2026-07-04  
+**Branch:** `feature/cursor/thermo-round2-redundancy`  
+**Baseline:** `dev`  
+**Worktree:** `.worktrees/dev-agent-cursor-thermo-round2-redundancy`  
+**Lifecycle:** ADR-0012 bounded-parallel (wave 0–2)
+
+## Executive summary
+
+- **Five redundant surfaces** compete for GenUI ownership: root `src/`/`agent/`, GenerativeUI `web-dashboard`, next-forge `generative-ui` island, and (deprecated) CopilotKit root proxy — only **next-forge + agent-server** should remain after Phase 4.
+- **Migration is 75% done:** Phase 2 schemas and Phase 3 client island pass; Phase 4 cutover blocked by missing feature-flag gating and no web-dashboard deprecation path.
+- **Two schema packages** (`@generative-ui/shared-schemas` zod v3 vs `@repo/schemas` zod v4) create drift risk despite golden JSON parity tests on the forge side.
+- **Orchestration duplication** in inbox pipelines (orchestrator vs workflow fan-out) and dual intake systems (Supabase inbox vs Copilot telemetry) need CLI rename + single entrypoint.
+- **Skill registry sprawl:** 4 local key collisions, 522 vendor skills — establish precedence and CI hash dedup before adding more.
+
+## Redundancy matrix
+
+| Zone                                                | Canonical owner                           | Severity | Archive readiness             |
+| --------------------------------------------------- | ----------------------------------------- | -------- | ----------------------------- |
+| Root `src/` (CopilotKit, bootstrap, panel registry) | `next-forge/apps/app`                     | Critical | Not ready — Phase 4           |
+| Root `agent/` (ADK, toolsets, genai-toolbox vendor) | `GenerativeUI_monorepo/apps/agent-server` | Critical | Not ready — Phase 4           |
+| `web-dashboard` GenerativeCanvas + useAgentState    | `next-forge/.../generative-ui/`           | High     | Blocked on schema unification |
+| `packages/shared-schemas`                           | `@repo/schemas`                           | High     | Retire after web-dashboard    |
+| CopilotKit in root `layout.tsx`                     | Remove with root archive                  | Medium   | Phase 4                       |
+| `intake-orchestrator.mjs` vs split GH workflows     | Single orchestrator caller                | Medium   | Ready to refactor             |
+| GenerativeUI `intake-pipeline/` (Python)            | Rename to `copilot-telemetry`             | Medium   | Document only                 |
+| `.agents` vs `.cursor` skill duplicates (4 keys)    | `.agents/skills/` canonical               | Medium   | Ready to dedup                |
+| UniversalWorkbench MCP registry                     | HTTP-only; separate product               | Low      | Keep isolated                 |
+
+## next-forge migration fit scorecard
+
+| Phase | Item                                  | Status                   |
+| ----- | ------------------------------------- | ------------------------ |
+| 1     | Storybook ModMe/Workshop exists       | PASS                     |
+| 1     | Real websocket-driven canvas story    | PARTIAL                  |
+| 2     | `@repo/schemas` + golden fixture      | PASS                     |
+| 2     | Python manual sync documented         | PASS (risk acknowledged) |
+| 3     | generative-ui route + client boundary | PASS                     |
+| 3     | use-agent-state + message handler     | PASS                     |
+| 3     | Reconnect backoff + Vitest            | PARTIAL                  |
+| 4     | Feature-flag gating                   | **FAIL**                 |
+| 4     | web-dashboard deprecation             | **FAIL**                 |
+| 4     | Worktree-aware WS URL                 | PARTIAL                  |
+
+## Parallel review findings (deduped)
+
+| Sev      | Lane        | Finding                                                     | Location                                             | Fix                                    |
+| -------- | ----------- | ----------------------------------------------------------- | ---------------------------------------------------- | -------------------------------------- |
+| Critical | Security    | Unauthenticated WS; broadcast to all connections            | `agent-server/.../websocket_route.py`                | Per-connection auth + scoped broadcast |
+| Critical | Security    | Unauthenticated CopilotKit proxy                            | `src/app/api/copilotkit/route.ts`                    | Auth + rate limit; fail closed         |
+| Critical | Correctness | Stale UI after reconnect (streaming/optimistic not cleared) | `use-agent-state.ts`, `websocket-message-handler.ts` | Reset on open + idle state_update      |
+| High     | Security    | Fixed `demo_user` identity                                  | `agent/main.py`                                      | Per-session user_id                    |
+| High     | Correctness | Cancel leaves optimistic messages pending                   | `use-agent-state.ts`                                 | Clear on cancel/idle                   |
+| High     | Correctness | Python `payload: Any` — no runtime validation               | `schemas.py`                                         | Discriminated union payloads           |
+| High     | Performance | N+1 Supabase in scrape-promote                              | `scripts/scrape-promote.mjs`                         | Batch insert/lookup                    |
+| High     | Performance | Per-token render churn                                      | `websocket-message-handler.ts`                       | Throttle via rAF                       |
+| High     | Readability | Monolithic useAgentState in legacy                          | `web-dashboard/.../useAgentState.ts`                 | Extract shared handler package         |
+| Medium   | Performance | Greptime fetchAll + client cosine                           | `greptimedb_client.ts`                               | Server-side ANN                        |
+| Medium   | Scripts     | intake-orchestrator mode spaghetti                          | `intake-orchestrator.mjs`                            | Declarative MODE→stages table          |
+| Medium   | Skills      | 4 duplicate local skill keys                                | `.agents` + `.cursor`                                | CI hash gate                           |
+
+## Architecture deepening candidates
+
+HTML report: `%TEMP%\architecture-review-2026-07-04.html` (open with `start` on Windows)
+
+| #   | Candidate                          | Strength            | Code-judo move                                        |
+| --- | ---------------------------------- | ------------------- | ----------------------------------------------------- |
+| 1   | Legacy root stub deletion seam     | **Strong**          | Archive `src/`+`agent/` → delete 2 entire stacks      |
+| 2   | Single `@repo/genui-client` module | **Strong**          | Collapse 3 GenerativeCanvas copies into one package   |
+| 3   | Schema single source + codegen     | **Strong**          | Retire shared-schemas; generate Pydantic from Zod     |
+| 4   | Skill catalog consolidation        | **Worth exploring** | `.agents` canonical + vendor hash CI                  |
+| 5   | Intake orchestration interface     | **Worth exploring** | One `yarn intake:*` → orchestrator; workflows call it |
+| 6   | UniversalWorkbench HTTP boundary   | **Speculative**     | Document-only; no cross-import                        |
+
+**Top recommendation:** Candidate #2 + #3 together — extract `@repo/genui-client` (hooks + canvas) and bind it to `@repo/schemas` only; then Phase 4 becomes flipping a feature flag and deleting web-dashboard + root stub.
+
+## Skills recommendations
+
+Already in collection: `thermo-nuclear-code-quality-review`, `modme-generative-ui-migrate`, `parallel-agents`, `garrytan/plan-eng-review`.
+
+**Proposed adds** (gaps found via `npx skills find`):
+
+| Skill                                                              | Install                                                                                             | Rationale                        |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `tech-leads-club/agent-skills@legacy-migration-planner`            | `npx skills add tech-leads-club/agent-skills@legacy-migration-planner --agent cursor -y`            | Phase 4 cutover planning         |
+| `cursor/plugins@principle-migrate-callers-then-delete-legacy-apis` | `npx skills add cursor/plugins@principle-migrate-callers-then-delete-legacy-apis --agent cursor -y` | Root stub deletion order         |
+| `srstomp/pokayokay@architecture-review`                            | optional                                                                                            | Cross-check deepening candidates |
+
+Local catalog cloned: `.tools/awesome-agent-skills/`
+
+## Agent contributions
+
+| Lane                        | Finding                                                               |
+| --------------------------- | --------------------------------------------------------------------- |
+| explorer-root               | Critical legacy duplication; harness canonical, scripts are operators |
+| explorer-forge              | Phase 2-3 pass; Phase 4 fail on feature flags                         |
+| explorer-legacy             | Dual schema packages; zod v3/v4 split                                 |
+| explorer-universalworkbench | Conceptual MCP registry overlap only                                  |
+| explorer-scripts            | Inbox orchestrator vs workflow drift; dual intake naming              |
+| explorer-skills             | 4 local + 6 vendor key collisions                                     |
+| thermo-security             | WS auth + CopilotKit proxy critical                                   |
+| thermo-performance          | N+1 intake, token render churn, Greptime client search                |
+| thermo-correctness          | Reconnect state staleness; Python payload Any                         |
+| thermo-readability          | Delete monolithic legacy hook; declarative intake modes               |
+
+## Verification gates
+
+| Gate           | Command                                                | Status                                |
+| -------------- | ------------------------------------------------------ | ------------------------------------- |
+| Harness lint   | `yarn lint:harness`                                    | **PASS**                              |
+| Molecule index | `yarn molecule-index:verify`                           | **PASS**                              |
+| WS golden      | `cd next-forge && bun test packages/schemas/*.test.ts` | **PASS** (11 tests)                   |
+| Forge CI       | `yarn verify:forge`                                    | Advisory — lint debt documented       |
+| Generative CI  | `yarn verify:generative`                               | Not required (no legacy code changes) |
+| Telemetry      | `yarn telemetry:audit --lens all`                      | Advisory                              |
+
+## Action items (ordered)
+
+1. [ ] Add `@repo/feature-flags` gating to `generative-ui/page.tsx` (Phase 4 blocker)
+2. [ ] Extract `@repo/genui-client` from next-forge island; point web-dashboard at it temporarily
+3. [ ] Unify on `@repo/schemas`; deprecate `@generative-ui/shared-schemas`
+4. [ ] Fix reconnect/cancel state reset in `use-agent-state.ts`
+5. [ ] Add WS auth to agent-server before production cutover
+6. [ ] Refactor inbox workflows to call `intake-orchestrator.mjs` only
+7. [ ] CI skill-key dedup gate (`.agents` vs `.cursor`)
+8. [ ] Execute Phase 4 archive: `src/` + `agent/` → `archive/legacy-genui-root/`
+9. [ ] Archive ECL change: `node scripts/harness-change.mjs archive thermo-round2-redundancy`
+
+## Related
+
+- Wave manifest: [`manifest.json`](manifest.json)
+- Prior run: [`thermo-nuclear-forge-2026-06-28.md`](thermo-nuclear-forge-2026-06-28.md)
+- Runbook: [`../thermo-nuclear-dual-monorepo-review.md`](../thermo-nuclear-dual-monorepo-review.md)
+- Domain glossary: [`CONTEXT.md`](../../CONTEXT.md)

--- a/docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md
+++ b/docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md
@@ -1,25 +1,25 @@
-# Thermo-Nuclear Redundancy Review — Synthesis (Round 2)
+# Thermo-Nuclear Redundancy Review â€” Synthesis (Round 2)
 
 **Date:** 2026-07-04  
 **Branch:** `feature/cursor/thermo-round2-redundancy`  
 **Baseline:** `dev`  
 **Worktree:** `.worktrees/dev-agent-cursor-thermo-round2-redundancy`  
-**Lifecycle:** ADR-0012 bounded-parallel (wave 0–2)
+**Lifecycle:** ADR-0012 bounded-parallel (wave 0â€“2)
 
 ## Executive summary
 
-- **Five redundant surfaces** compete for GenUI ownership: root `src/`/`agent/`, GenerativeUI `web-dashboard`, next-forge `generative-ui` island, and (deprecated) CopilotKit root proxy — only **next-forge + agent-server** should remain after Phase 4.
+- **Five redundant surfaces** compete for GenUI ownership: root `src/`/`agent/`, GenerativeUI `web-dashboard`, next-forge `generative-ui` island, and (deprecated) CopilotKit root proxy â€” only **next-forge + agent-server** should remain after Phase 4.
 - **Migration is 75% done:** Phase 2 schemas and Phase 3 client island pass; Phase 4 cutover blocked by missing feature-flag gating and no web-dashboard deprecation path.
 - **Two schema packages** (`@generative-ui/shared-schemas` zod v3 vs `@repo/schemas` zod v4) create drift risk despite golden JSON parity tests on the forge side.
 - **Orchestration duplication** in inbox pipelines (orchestrator vs workflow fan-out) and dual intake systems (Supabase inbox vs Copilot telemetry) need CLI rename + single entrypoint.
-- **Skill registry sprawl:** 4 local key collisions, 522 vendor skills — establish precedence and CI hash dedup before adding more.
+- **Skill registry sprawl:** 4 local key collisions, 522 vendor skills â€” establish precedence and CI hash dedup before adding more.
 
 ## Redundancy matrix
 
 | Zone                                                | Canonical owner                           | Severity | Archive readiness             |
 | --------------------------------------------------- | ----------------------------------------- | -------- | ----------------------------- |
-| Root `src/` (CopilotKit, bootstrap, panel registry) | `next-forge/apps/app`                     | Critical | Not ready — Phase 4           |
-| Root `agent/` (ADK, toolsets, genai-toolbox vendor) | `GenerativeUI_monorepo/apps/agent-server` | Critical | Not ready — Phase 4           |
+| Root `src/` (CopilotKit, bootstrap, panel registry) | `next-forge/apps/app`                     | Critical | Not ready â€” Phase 4           |
+| Root `agent/` (ADK, toolsets, genai-toolbox vendor) | `GenerativeUI_monorepo/apps/agent-server` | Critical | Not ready â€” Phase 4           |
 | `web-dashboard` GenerativeCanvas + useAgentState    | `next-forge/.../generative-ui/`           | High     | Blocked on schema unification |
 | `packages/shared-schemas`                           | `@repo/schemas`                           | High     | Retire after web-dashboard    |
 | CopilotKit in root `layout.tsx`                     | Remove with root archive                  | Medium   | Phase 4                       |
@@ -52,12 +52,12 @@
 | Critical | Correctness | Stale UI after reconnect (streaming/optimistic not cleared) | `use-agent-state.ts`, `websocket-message-handler.ts` | Reset on open + idle state_update      |
 | High     | Security    | Fixed `demo_user` identity                                  | `agent/main.py`                                      | Per-session user_id                    |
 | High     | Correctness | Cancel leaves optimistic messages pending                   | `use-agent-state.ts`                                 | Clear on cancel/idle                   |
-| High     | Correctness | Python `payload: Any` — no runtime validation               | `schemas.py`                                         | Discriminated union payloads           |
+| High     | Correctness | Python `payload: Any` â€” no runtime validation               | `schemas.py`                                         | Discriminated union payloads           |
 | High     | Performance | N+1 Supabase in scrape-promote                              | `scripts/scrape-promote.mjs`                         | Batch insert/lookup                    |
 | High     | Performance | Per-token render churn                                      | `websocket-message-handler.ts`                       | Throttle via rAF                       |
 | High     | Readability | Monolithic useAgentState in legacy                          | `web-dashboard/.../useAgentState.ts`                 | Extract shared handler package         |
 | Medium   | Performance | Greptime fetchAll + client cosine                           | `greptimedb_client.ts`                               | Server-side ANN                        |
-| Medium   | Scripts     | intake-orchestrator mode spaghetti                          | `intake-orchestrator.mjs`                            | Declarative MODE→stages table          |
+| Medium   | Scripts     | intake-orchestrator mode spaghetti                          | `intake-orchestrator.mjs`                            | Declarative MODEâ†’stages table          |
 | Medium   | Skills      | 4 duplicate local skill keys                                | `.agents` + `.cursor`                                | CI hash gate                           |
 
 ## Architecture deepening candidates
@@ -66,14 +66,14 @@ HTML report: `%TEMP%\architecture-review-2026-07-04.html` (open with `start` on 
 
 | #   | Candidate                          | Strength            | Code-judo move                                        |
 | --- | ---------------------------------- | ------------------- | ----------------------------------------------------- |
-| 1   | Legacy root stub deletion seam     | **Strong**          | Archive `src/`+`agent/` → delete 2 entire stacks      |
+| 1   | Legacy root stub deletion seam     | **Strong**          | Archive `src/`+`agent/` â†’ delete 2 entire stacks      |
 | 2   | Single `@repo/genui-client` module | **Strong**          | Collapse 3 GenerativeCanvas copies into one package   |
 | 3   | Schema single source + codegen     | **Strong**          | Retire shared-schemas; generate Pydantic from Zod     |
 | 4   | Skill catalog consolidation        | **Worth exploring** | `.agents` canonical + vendor hash CI                  |
-| 5   | Intake orchestration interface     | **Worth exploring** | One `yarn intake:*` → orchestrator; workflows call it |
+| 5   | Intake orchestration interface     | **Worth exploring** | One `yarn intake:*` â†’ orchestrator; workflows call it |
 | 6   | UniversalWorkbench HTTP boundary   | **Speculative**     | Document-only; no cross-import                        |
 
-**Top recommendation:** Candidate #2 + #3 together — extract `@repo/genui-client` (hooks + canvas) and bind it to `@repo/schemas` only; then Phase 4 becomes flipping a feature flag and deleting web-dashboard + root stub.
+**Top recommendation:** Candidate #2 + #3 together â€” extract `@repo/genui-client` (hooks + canvas) and bind it to `@repo/schemas` only; then Phase 4 becomes flipping a feature flag and deleting web-dashboard + root stub.
 
 ## Skills recommendations
 
@@ -111,7 +111,7 @@ Local catalog cloned: `.tools/awesome-agent-skills/`
 | Harness lint   | `yarn lint:harness`                                    | **PASS**                              |
 | Molecule index | `yarn molecule-index:verify`                           | **PASS**                              |
 | WS golden      | `cd next-forge && bun test packages/schemas/*.test.ts` | **PASS** (11 tests)                   |
-| Forge CI       | `yarn verify:forge`                                    | Advisory — lint debt documented       |
+| Forge CI       | `yarn verify:forge`                                    | Advisory â€” lint debt documented       |
 | Generative CI  | `yarn verify:generative`                               | Not required (no legacy code changes) |
 | Telemetry      | `yarn telemetry:audit --lens all`                      | Advisory                              |
 
@@ -124,12 +124,12 @@ Local catalog cloned: `.tools/awesome-agent-skills/`
 5. [ ] Add WS auth to agent-server before production cutover
 6. [ ] Refactor inbox workflows to call `intake-orchestrator.mjs` only
 7. [ ] CI skill-key dedup gate (`.agents` vs `.cursor`)
-8. [ ] Execute Phase 4 archive: `src/` + `agent/` → `archive/legacy-genui-root/`
-9. [ ] Archive ECL change: `node scripts/harness-change.mjs archive thermo-round2-redundancy`
+8. [ ] Execute Phase 4 archive: `src/` + `agent/` â†’ `archive/legacy-genui-root/`
+9. [x] Archive ECL change: `node scripts/harness-change.mjs archive thermo-round2-redundancy`
 
 ## Related
 
 - Wave manifest: [`manifest.json`](manifest.json)
 - Prior run: [`thermo-nuclear-forge-2026-06-28.md`](thermo-nuclear-forge-2026-06-28.md)
 - Runbook: [`../thermo-nuclear-dual-monorepo-review.md`](../thermo-nuclear-dual-monorepo-review.md)
-- Domain glossary: [`CONTEXT.md`](../../CONTEXT.md)
+- Domain glossary: [`CONTEXT.md`](../../../CONTEXT.md)

--- a/harness/changes/archive/thermo-round2-redundancy/CHANGE.md
+++ b/harness/changes/archive/thermo-round2-redundancy/CHANGE.md
@@ -1,0 +1,38 @@
+# thermo-round2-redundancy
+
+> Structured change — see [docs/ECL.md](../../../docs/ECL.md)
+
+## Goal
+
+Round 2 thermo-nuclear review: map redundancies across Root, next-forge, GenerativeUI, scripts, and agent-skills; produce architecture deepening report and migration fit scorecard against `dev` baseline.
+
+## Scope
+
+- In scope: redundancy matrix, parallel security/performance/correctness/readability review, `CONTEXT.md`, `docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md`, wave-1 `manifest.json`, CONCERNS/STRUCTURE evidence refresh
+- Out of scope: UniversalWorkbench-dev/staging, code fixes, Phase 4 cutover execution, lockfile merge
+
+## Baseline
+
+- Branch: `feature/cursor/thermo-round2-redundancy` from `dev`
+- Worktree: `.worktrees/dev-agent-cursor-thermo-round2-redundancy`
+
+## Verify
+
+```powershell
+yarn lint:harness          # PASS 2026-07-04
+yarn molecule-index:verify   # PASS 2026-07-04
+cd next-forge && bun test packages/schemas/*.test.ts
+```
+
+## Evidence
+
+- [`docs/workflows/reports/manifest.json`](../../../docs/workflows/reports/manifest.json)
+- [`docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md`](../../../docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md)
+- [`CONTEXT.md`](../../../CONTEXT.md)
+- Architecture HTML: `%TEMP%\architecture-review-2026-07-04.html`
+
+## Status
+
+- Wave 1 explorers: complete
+- Wave 2 parallel review: complete
+- Synthesis: complete

--- a/harness/changes/archive/thermo-round2-redundancy/CHANGE.md
+++ b/harness/changes/archive/thermo-round2-redundancy/CHANGE.md
@@ -1,6 +1,6 @@
 # thermo-round2-redundancy
 
-> Structured change — see [docs/ECL.md](../../../docs/ECL.md)
+> Structured change â€” see [docs/ECL.md](../../../../docs/ECL.md)
 
 ## Goal
 
@@ -26,9 +26,9 @@ cd next-forge && bun test packages/schemas/*.test.ts
 
 ## Evidence
 
-- [`docs/workflows/reports/manifest.json`](../../../docs/workflows/reports/manifest.json)
-- [`docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md`](../../../docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md)
-- [`CONTEXT.md`](../../../CONTEXT.md)
+- [`docs/workflows/reports/manifest.json`](../../../../docs/workflows/reports/manifest.json)
+- [`docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md`](../../../../docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md)
+- [`CONTEXT.md`](../../../../CONTEXT.md)
 - Architecture HTML: `%TEMP%\architecture-review-2026-07-04.html`
 
 ## Status

--- a/harness/changes/archive/thermo-round2-redundancy/STATUS.md
+++ b/harness/changes/archive/thermo-round2-redundancy/STATUS.md
@@ -1,0 +1,1 @@
+status: active

--- a/harness/changes/archive/thermo-round2-redundancy/STATUS.md
+++ b/harness/changes/archive/thermo-round2-redundancy/STATUS.md
@@ -1,1 +1,1 @@
-status: active
+status: archived


### PR DESCRIPTION
## Summary
- Publish Thermo-Nuclear Round 2 synthesis report with redundancy matrix and migration fit scorecard (Phases 1-4).
- Add root CONTEXT.md domain glossary for architecture reviews.
- Refresh docs/codebase/CONCERNS.md with Round 2 findings; update wave-2 manifest.json.
- Archive ECL change harness/changes/archive/thermo-round2-redundancy/.

## Review gates (passed)
- yarn lint:harness
- yarn pre-commit:check (changelog + ECL)
- yarn molecule-index:verify (prior session)
- bun test packages/schemas/*.test.ts (11 tests, prior session)
- pre-push verify-stack (docs-only paths, skipped forge/generative)

## Test plan
- [x] yarn lint:harness
- [x] yarn pre-commit:check
- [x] Review synthesis doc links resolve
- [ ] Optional: open architecture HTML at %TEMP%\\architecture-review-2026-07-04.html (local artifact, not committed)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes the Thermo‑Nuclear Round 2 redundancy synthesis and wave‑2 manifest, and adds a repo‑wide domain glossary. Refreshes CONCERNS evidence and molecule index to guide Phase 4, and archives the related ECL change.

- Publish Round 2 synthesis report `docs/workflows/reports/thermo-nuclear-redundancy-2026-07-04.md` with redundancy matrix, security/perf/correctness findings, verification gates, and ordered actions; linked from the wave‑2 reports manifest.
- Add root `CONTEXT.md` domain glossary; update `docs/codebase/CONCERNS.md` with Round 2 risks and test gaps, and reference Phase 4 cutover docs.
- Update `docs/workflows/reports/manifest.json` to wave‑2 (lanes, scope/baseline, synthesis path) and refresh `data/molecule-index/manifest.json` (timestamp; set zod `route_hint` to `dashboard`); record in `CHANGELOG.md`.
- Archive ECL change under `harness/changes/archive/thermo-round2-redundancy/` and mark `STATUS` archived; align manifest counts/links.

<sup>Written for commit a6d6d984799d0745aff4c655dea495102f210942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ditto190/modme-ui-01/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

