### PR TITLE
fix(docs): relative root in inbox audit latest.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ Skip changelog updates for typo-only edits, vendored mirror refreshes with no lo
 
 ### Fixed
 
-- (docs) Inbox audit report `latest.json` uses relative `root` (no machine-local path) (PR #89)
 - (scope) Short description (#issue)
 ```
 
@@ -149,7 +148,6 @@ CI runs `node scripts/validate-changelog.mjs` on pull requests. See `docs/agent-
 
 ### Fixed
 
-- (docs) Inbox audit report `latest.json` uses relative `root` (no machine-local path) (PR #89)
 - (dev) `init-worktrees.ps1` — use `$LASTEXITCODE` for git branch detection; disable direnv during setup (no spurious `direnv: error` / `branch already exists`)
 - (dev) `new-agent-worktree.ps1` — usage help when `-Name` omitted; `DIRENV_DISABLE` during creation; default `-Owner cursor`
 - (vscode) Set `git.path` in `.vscode/settings.json` so Cursor Agent Review finds Git on Windows when it is not on PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Skip changelog updates for typo-only edits, vendored mirror refreshes with no lo
 
 ### Fixed
 
+- (docs) Inbox audit report `latest.json` uses relative `root` (no machine-local path) (PR #89)
 - (scope) Short description (#issue)
 ```
 
@@ -97,6 +98,7 @@ CI runs `node scripts/validate-changelog.mjs` on pull requests. See `docs/agent-
 
 ### Fixed
 
+- (docs) Inbox audit report `latest.json` uses relative `root` (no machine-local path) (PR #89)
 - (scripts) `Get-CopilotRepoRoot` ascends 3 levels from `scripts/copilot-workspace/lib/paths.ps1`; null-safe `.Trim()` on git outputs in hooks/doctor scripts; schema-valid agent-gateway collection (PR #91)
 - (repo) Builder/preflight/hook spawns — Windows cmd shim via shell string (not `shell:true`+args); lean-ctx probe requires successful `--version`; `session-archive.ps1` checks `preflight:fast` exit code
 
@@ -147,6 +149,7 @@ CI runs `node scripts/validate-changelog.mjs` on pull requests. See `docs/agent-
 
 ### Fixed
 
+- (docs) Inbox audit report `latest.json` uses relative `root` (no machine-local path) (PR #89)
 - (dev) `init-worktrees.ps1` — use `$LASTEXITCODE` for git branch detection; disable direnv during setup (no spurious `direnv: error` / `branch already exists`)
 - (dev) `new-agent-worktree.ps1` — usage help when `-Name` omitted; `DIRENV_DISABLE` during creation; default `-Owner cursor`
 - (vscode) Set `git.path` in `.vscode/settings.json` so Cursor Agent Review finds Git on Windows when it is not on PATH

--- a/docs/inbox-pipeline/reports/latest.json
+++ b/docs/inbox-pipeline/reports/latest.json
@@ -756,5 +756,5 @@
     "markdown": "docs/inbox-pipeline/reports/latest.md",
     "jsonl": ".cursor/hooks/state/inbox-errors.jsonl"
   },
-  "root": "C:\\Users\\dylan\\Monorepo_ModMe"
+  "root": "."
 }


### PR DESCRIPTION
## Summary
- Replaces machine-local `C:\Users\dylan\...` `root` in `docs/inbox-pipeline/reports/latest.json` with `.`.
- Supersedes conflicting PR #89 (chat-suggestion branch) with a clean 1-commit branch from current `dev`.

## Test plan
- [x] Confirm `root` is `.` (no absolute user path)
- [ ] `yarn inbox:audit` still writes a portable root (follow-up if generator still emits absolute paths)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a relative root (".") in `docs/inbox-pipeline/reports/latest.json` to remove machine-local paths and keep the inbox audit report portable. Cleaned the CHANGELOG template and removed a duplicate entry, keeping a single fix under the first Fixed section.

<sup>Written for commit ce176a27fae004aa9cd80c077fbdcdb1cfd7efaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ditto190/modme-ui-01/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

