### PR TITLE
docs(lean-ctx): D-drive workspace profiles and sessionStart hook

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,1 +1,11 @@
-[]
+﻿{
+    "version":  1,
+    "hooks":  {
+                  "sessionStart":  [
+                                       {
+                                           "command":  "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ensure-lean-ctx-config.ps1 -CheckOnly",
+                                           "timeout":  90
+                                       }
+                                   ]
+              }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ CI runs `node scripts/validate-changelog.mjs` on pull requests. See `docs/agent-
 
 ## [Unreleased]
 
+### Added
+
+- (docs) lean-ctx D-drive workspace profiles guide (docs/lean-ctx/workspace-profiles.md) and Cursor sessionStart hook for lean-ctx config check
+
 ### Changed
 
 - (repo) Merge `github/main` into promotion branch `feature/cursor/promote-dev-to-main` to resolve dual-branch drift before promoting `dev` to `main`

--- a/docs/lean-ctx/workspace-profiles.md
+++ b/docs/lean-ctx/workspace-profiles.md
@@ -1,0 +1,46 @@
+# Github_Projects lean-ctx workspace profiles
+
+## Config tiers
+
+1. **Env vars** (`LEAN_CTX_*`) — highest
+2. **Project** `<repo>/.lean-ctx.toml`
+3. **D: workspace global** `D:\Github_Projects\.config\lean-ctx\config.toml` when `LEAN_CTX_CONFIG_DIR` is set (via [Github_Projects.code-workspace](../../Github_Projects.code-workspace))
+4. **C: user global** `~\.config\lean-ctx\config.toml` when workspace env is unset
+
+## Session automation
+
+| Trigger | Script |
+| --- | --- |
+| Cursor `sessionStart` (workspace hooks) | `scripts/github-projects-healthcheck.ps1` |
+| Integrated terminal profile `GP PowerShell (lean-ctx)` | `scripts/github-projects-session-bootstrap.ps1` |
+
+Bootstrap runs once per calendar day (marker under `.cursor/hooks/state/`). Use `-Force` to re-run.
+
+## Activate a skill-aligned profile
+
+```powershell
+$env:LEAN_CTX_PROFILE = "powershell-windows"   # or ai-native-cli, windows-shell-reliability, bash-shell, os-scripting
+$env:LEAN_CTX_PERSONA = "powershell-windows"
+# list: lean-ctx profile list
+```
+
+| Profile / persona | Skill alignment |
+| --- | --- |
+| `powershell-windows` | powershell-windows |
+| `windows-shell-reliability` | windows-shell-reliability |
+| `ai-native-cli` | ai-native-cli |
+| `bash-shell` | bash / shell |
+| `os-scripting` | os-scripting |
+| `shell` (persona only) | /shell |
+
+Personas: `.config/lean-ctx/personas/`. Context profiles: `.local/share/lean-ctx/profiles/` (when `LEAN_CTX_DATA_DIR` points at the D: workspace).
+
+## Verify
+
+```powershell
+$env:LEAN_CTX_CONFIG_DIR = "D:\Github_Projects\.config\lean-ctx"
+lean-ctx config validate
+lean-ctx doctor
+.\scripts\github-projects-healthcheck.ps1 -Json
+.\scripts\github-projects-session-bootstrap.ps1 -Force
+```


### PR DESCRIPTION
## Summary
- Add `docs/lean-ctx/workspace-profiles.md` documenting D:\Github_Projects lean-ctx config tiers and profiles
- Wire Cursor `sessionStart` hook to `scripts/ensure-lean-ctx-config.ps1 -CheckOnly`
- Changelog Unreleased entry for the docs/hook change

## Test plan
- [ ] Confirm `docs/lean-ctx/workspace-profiles.md` renders correctly
- [ ] Optional: open Cursor with this worktree and verify sessionStart hook runs without failing the session

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `lean-ctx` workspace profiles docs for `D:\Github_Projects` and wired a `Cursor` `sessionStart` hook to run a config check, reducing session issues from misconfiguration.

- **New Features**
  - Added `docs/lean-ctx/workspace-profiles.md` covering config tiers, profiles/personas, and verification commands.
  - Updated `.cursor/hooks.json` to run `scripts/ensure-lean-ctx-config.ps1 -CheckOnly` on `sessionStart` (90s timeout), and noted in `CHANGELOG.md`.

<sup>Written for commit 069ae616cc0aa4e564780defad7a7c203e07fbac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ditto190/modme-ui-01/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

