### PR TITLE
feat(worktrees): harden Copilot worktree scripts and lean-ctx profiles

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,40 +1,44 @@
-{
-  "hooks": {
-    "beforeSubmitPrompt": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor before-submit-prompt'"
-      }
-    ],
-    "preCompact": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor pre-compact'"
-      }
-    ],
-    "sessionEnd": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-end'"
-      }
-    ],
-    "sessionStart": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-start'"
-      }
-    ],
-    "stop": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor stop'"
-      }
-    ],
-    "subagentStart": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-start'"
-      }
-    ],
-    "subagentStop": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-stop'"
-      }
-    ]
-  },
-  "version": 1
+﻿{
+    "hooks":  {
+                  "beforeSubmitPrompt":  [
+                                             {
+                                                 "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor before-submit-prompt\u0027"
+                                             }
+                                         ],
+                  "preCompact":  [
+                                     {
+                                         "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor pre-compact\u0027"
+                                     }
+                                 ],
+                  "sessionEnd":  [
+                                     {
+                                         "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor session-end\u0027"
+                                     }
+                                 ],
+                  "stop":  [
+                               {
+                                   "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor stop\u0027"
+                               }
+                           ],
+                  "subagentStart":  [
+                                        {
+                                            "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor subagent-start\u0027"
+                                        }
+                                    ],
+                  "subagentStop":  [
+                                       {
+                                           "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor subagent-stop\u0027"
+                                       }
+                                   ],
+                  "sessionStart":  [
+                                       {
+                                           "command":  "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ensure-lean-ctx-config.ps1 -CheckOnly",
+                                           "timeout":  90
+                                       },
+                                       {
+                                           "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor session-start\u0027"
+                                       }
+                                   ]
+              },
+    "version":  1
 }

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ target/
 *.tsbuildinfo
 
 # Worktree local artifacts (git manages worktree dirs themselves)
+.worktrees/
 .worktrees/**/.worktree-ports.env
 .worktrees/**/logs/
 .lean-ctx/

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,28 +1,31 @@
+
+
 # list of languages for which language servers are started; choose from:
-#   al               bash             clojure          cpp              csharp           csharp_omnisharp
-#   dart             elixir           elm              erlang           fortran          go
-#   haskell          java             julia            kotlin           lua              markdown
-#   nix              perl             php              python           python_jedi      r
-#   rego             ruby             ruby_solargraph  rust             scala            swift
-#   terraform        typescript       typescript_vts   yaml             zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
-#   - csharp: Requires the presence of a .sln file in the project folder.
-#   dart             elixir           elm              erlang           fortran          fsharp
-#   go               groovy           haskell          java             julia            kotlin
-#   lua              markdown         nix              pascal           perl             php
-#   powershell       python           python_jedi      r                rego             ruby
-#   ruby_solargraph  rust             scala            swift            terraform        toml
-#   typescript       typescript_vts   yaml             zig
-# Note:
-#   - For C, use cpp
-#   - For JavaScript, use typescript
-#   - For Free Pascal / Lazarus, use pascal
-# Special requirements:
-#   - csharp: Requires the presence of a .sln file in the project folder.
-#   - pascal: Requires Free Pascal Compiler (fpc) and optionally Lazarus.
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
 # When using multiple languages, the first language server that supports a given file will be used for that file.
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
@@ -65,14 +68,12 @@ languages:
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
 encoding: "utf-8"
 
-# whether to use the project's gitignore file to ignore files
-# Added on 2025-04-07
+# whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore
-# same syntax as gitignore, so you can use * and **
-# Was previously called `ignored_dirs`, please update your config if you are using that.
-# Added (renamed) on 2025-04-07
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -80,50 +81,85 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-
+# the name by which the project can be referenced within Serena
 project_name: "relaxed-hugle"
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -11,7 +11,6 @@ next-forge/packages/database/.env
 # lockfiles for shared-deps bootstrap
 yarn.lock
 .yarnrc.yml
-.yarn/
 next-forge/bun.lock
 GenerativeUI_monorepo/apps/agent-server/poetry.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ CI runs `node scripts/validate-changelog.mjs` on pull requests. See `docs/agent-
 - (repo) KM session startup wiring — `scripts/km-session-bootstrap.ps1` (`yarn km:bootstrap`), session start + worktree setup + VS Code tasks/launch (`Full Stack: Forge Core + Agent Data Plane`, soft `dependsOn` on `next-forge: dev core`); ADR-0014; beads `modme-awz`; runbook `docs/monorepo/km-agent-data-plane-startup.md`
 
 ### Changed
+- (worktrees) Harden Copilot worktree bootstrap scripts and lean-ctx workspace profiles
 
 - (repo) Merge `github/main` into promotion branch `feature/cursor/promote-dev-to-main` to resolve dual-branch drift before promoting `dev` to `main`
 

--- a/docs/copilot-workspace-orchestration.md
+++ b/docs/copilot-workspace-orchestration.md
@@ -48,7 +48,7 @@ flowchart LR
 | File                                                          | Purpose                                                                                  |
 | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | [`.github/github-app.yml`](../.github/github-app.yml)         | Trust config: automation, branch prefix, system-prompt includes, lifecycle + Run scripts |
-| [`.worktreeinclude`](../.worktreeinclude)                     | Copy gitignored `.env`, lockfiles, `.yarn/` into new Copilot worktrees                   |
+| [`.worktreeinclude`](../.worktreeinclude)                     | Copy gitignored `.env` and lockfile bootstrap files into new Copilot worktrees            |
 | [`scripts/copilot-workspace/`](../scripts/copilot-workspace/) | `session.create` / `session.archive` implementation                                      |
 | [`.copilot/workspace.generated.env`](../.copilot/)            | Generated ModMe env (gitignored)                                                         |
 
@@ -68,6 +68,19 @@ Injected by Copilot App into lifecycle and Run scripts:
 | `COPILOT_PORT`           | Port seed; mapped to `FORGE_APP_PORT` in generated env      |
 
 Generated file `.copilot/workspace.generated.env` also includes `.worktree-ports.env` values after `worktree-allocate-ports.ps1`.
+
+---
+
+## Worktree root resolution
+
+Worktree scripts resolve the root in this order:
+
+1. `WORKTREES_ROOT` (if set)
+2. `MODME_WORKTREES_ROOT` (if set)
+3. `D:\Github_Projects\copilot-worktrees\<project>` (when `D:\` exists)
+4. `<repo>\.worktrees` (fallback)
+
+This keeps SSD storage as the default on machines with the external drive attached while preserving a local fallback.
 
 ---
 
@@ -178,4 +191,4 @@ Import Obsidian templates from `templates/obsidian-clipper/*.json`.
 | Bootstrap         | `setup-worktree-windows.ps1`         | `copilot-workspace/bootstrap.ps1` |
 | Shared core       | `scripts/lib/worktree-bootstrap.ps1` | same                              |
 
-Never implement feature work in the main checkout — use `.worktrees/` per [`multi-agent-worktrees.md`](multi-agent-worktrees.md).
+Never implement feature work in the main checkout — use the configured worktree root per [`multi-agent-worktrees.md`](multi-agent-worktrees.md).

--- a/docs/lean-ctx/workspace-profiles.md
+++ b/docs/lean-ctx/workspace-profiles.md
@@ -1,0 +1,46 @@
+# Github_Projects lean-ctx workspace profiles
+
+## Config tiers
+
+1. **Env vars** (`LEAN_CTX_*`) — highest
+2. **Project** `<repo>/.lean-ctx.toml`
+3. **D: workspace global** `D:\Github_Projects\.config\lean-ctx\config.toml` when `LEAN_CTX_CONFIG_DIR` is set (via [Github_Projects.code-workspace](../../Github_Projects.code-workspace))
+4. **C: user global** `~\.config\lean-ctx\config.toml` when workspace env is unset
+
+## Session automation
+
+| Trigger | Script |
+| --- | --- |
+| Cursor `sessionStart` (workspace hooks) | `scripts/github-projects-healthcheck.ps1` |
+| Integrated terminal profile `GP PowerShell (lean-ctx)` | `scripts/github-projects-session-bootstrap.ps1` |
+
+Bootstrap runs once per calendar day (marker under `.cursor/hooks/state/`). Use `-Force` to re-run.
+
+## Activate a skill-aligned profile
+
+```powershell
+$env:LEAN_CTX_PROFILE = "powershell-windows"   # or ai-native-cli, windows-shell-reliability, bash-shell, os-scripting
+$env:LEAN_CTX_PERSONA = "powershell-windows"
+# list: lean-ctx profile list
+```
+
+| Profile / persona | Skill alignment |
+| --- | --- |
+| `powershell-windows` | powershell-windows |
+| `windows-shell-reliability` | windows-shell-reliability |
+| `ai-native-cli` | ai-native-cli |
+| `bash-shell` | bash / shell |
+| `os-scripting` | os-scripting |
+| `shell` (persona only) | /shell |
+
+Personas: `.config/lean-ctx/personas/`. Context profiles: `.local/share/lean-ctx/profiles/` (when `LEAN_CTX_DATA_DIR` points at the D: workspace).
+
+## Verify
+
+```powershell
+$env:LEAN_CTX_CONFIG_DIR = "D:\Github_Projects\.config\lean-ctx"
+lean-ctx config validate
+lean-ctx doctor
+.\scripts\github-projects-healthcheck.ps1 -Json
+.\scripts\github-projects-session-bootstrap.ps1 -Force
+```

--- a/scripts/ensure-worktree.ps1
+++ b/scripts/ensure-worktree.ps1
@@ -1,4 +1,4 @@
-# Fail fast when feature work runs from the main checkout instead of .worktrees/.
+# Fail fast when feature work runs from the main checkout instead of a dedicated worktree root.
 param(
   [switch]$WarnOnly
 )
@@ -27,7 +27,7 @@ $ctx = Get-WorktreeContext -RepoRoot $RepoRoot
 
 function Write-WorktreeHint {
   Write-Host ""
-  Write-Host "Feature work belongs in a worktree under .worktrees/" -ForegroundColor Yellow
+  Write-Host "Feature work belongs in a dedicated worktree root: $($ctx.WorktreesRoot)" -ForegroundColor Yellow
   Write-Host "  .\scripts\init-worktrees.ps1                    # persistent dev checkout" -ForegroundColor Gray
   Write-Host "  .\scripts\new-agent-worktree.ps1 -Name `"<task>`" -Owner cursor" -ForegroundColor Gray
   Write-Host "  .\scripts\migrate-main-to-worktree.ps1 -Name `"<task>`" -Owner cursor" -ForegroundColor Gray
@@ -39,7 +39,7 @@ if ($ctx.IsWorktree) {
   exit 0
 }
 
-$message = "Main checkout detected ($($ctx.RepoRoot)). Use a worktree under .worktrees/ for feature work."
+$message = "Main checkout detected ($($ctx.RepoRoot)). Use a worktree under $($ctx.WorktreesRoot) for feature work."
 
 if ($WarnOnly) {
   Write-Warning $message

--- a/scripts/init-worktrees.ps1
+++ b/scripts/init-worktrees.ps1
@@ -13,13 +13,16 @@ $prevDirenvDisable = $env:DIRENV_DISABLE
 $env:DIRENV_DISABLE = "1"
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+. "$ScriptDir/lib/worktree-context.ps1"
 $ProjectMainDir = Split-Path -Parent $ScriptDir
-$ProjectName = Split-Path -Leaf $ProjectMainDir
-$MonorepoRoot = Split-Path -Parent $ProjectMainDir
+$ctx = Get-WorktreeContext -RepoRoot $ProjectMainDir
+$MainRepoRoot = $ctx.MainRepoRoot
+$ProjectName = Split-Path -Leaf $MainRepoRoot
+$MonorepoRoot = Split-Path -Parent $MainRepoRoot
 
 function Test-GitBranchExists {
   param([string]$BranchName)
-  git -C $ProjectMainDir show-ref --verify --quiet "refs/heads/$BranchName" 2>$null
+  git -C $MainRepoRoot show-ref --verify --quiet "refs/heads/$BranchName" 2>$null
   return ($LASTEXITCODE -eq 0)
 }
 
@@ -29,16 +32,16 @@ function Ensure-Branch ($BranchName) {
     return
   }
   Write-Host "   Creating branch '$BranchName'..." -ForegroundColor Yellow
-  git -C $ProjectMainDir branch $BranchName
+  git -C $MainRepoRoot branch $BranchName
   if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to create branch '$BranchName'"
   }
-  $remoteExists = git -C $ProjectMainDir ls-remote --heads origin $BranchName 2>$null
+  $remoteExists = git -C $MainRepoRoot ls-remote --heads origin $BranchName 2>$null
   if ($remoteExists) {
     Write-Host "   Remote branch '$BranchName' already exists on origin." -ForegroundColor Gray
   }
   else {
-    git -C $ProjectMainDir push -u origin $BranchName 2>$null
+    git -C $MainRepoRoot push -u origin $BranchName 2>$null
     if ($LASTEXITCODE -eq 0) {
       Write-Host "   Pushed '$BranchName' to origin." -ForegroundColor Gray
     }
@@ -51,7 +54,8 @@ try {
   Write-Host "===========================================" -ForegroundColor Cyan
   Write-Host ""
   Write-Host "   Project: $ProjectName" -ForegroundColor Green
-  Write-Host "   Main Dir: $ProjectMainDir"
+  Write-Host "   Main Dir: $MainRepoRoot"
+  Write-Host "   Root:     $($ctx.WorktreesRoot)"
   Write-Host "   Parent:   $MonorepoRoot"
   Write-Host ""
 
@@ -65,16 +69,16 @@ try {
     Ensure-Branch "staging"
   }
 
-  $WorktreesRoot = Join-Path $ProjectMainDir ".worktrees"
+  $WorktreesRoot = $ctx.WorktreesRoot
   if (!(Test-Path $WorktreesRoot)) {
     Write-Host "   Creating worktrees root at $WorktreesRoot..." -ForegroundColor Yellow
     New-Item -ItemType Directory -Force -Path $WorktreesRoot | Out-Null
   }
 
-  $DevCheckout = Join-Path $WorktreesRoot "dev"
+  $DevCheckout = $ctx.DevCheckout
   if (!(Test-Path $DevCheckout)) {
     Write-Host "   Creating persistent dev checkout at $DevCheckout..." -ForegroundColor Yellow
-    git -C $ProjectMainDir worktree add $DevCheckout dev
+    git -C $MainRepoRoot worktree add $DevCheckout dev
     if ($LASTEXITCODE -ne 0) { Write-Error "Failed to create dev worktree" }
     Write-Host "   Dev worktree created." -ForegroundColor Green
   }
@@ -86,7 +90,7 @@ try {
     $StagingWorktreePath = Join-Path $MonorepoRoot "$ProjectName-staging"
     if (!(Test-Path $StagingWorktreePath)) {
       Write-Host "   Creating staging worktree at $StagingWorktreePath..." -ForegroundColor Yellow
-      git -C $ProjectMainDir worktree add $StagingWorktreePath staging
+      git -C $MainRepoRoot worktree add $StagingWorktreePath staging
       Write-Host "   Staging worktree created." -ForegroundColor Green
     }
     else {

--- a/scripts/lib/worktree-context.ps1
+++ b/scripts/lib/worktree-context.ps1
@@ -1,5 +1,27 @@
 # Shared worktree path detection for ModMe scripts (dot-source from scripts/*.ps1).
 
+function Resolve-PreferredWorktreesRoot {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$MainRepoRoot
+  )
+
+  $projectName = Split-Path -Leaf $MainRepoRoot
+  foreach ($candidate in @($env:WORKTREES_ROOT, $env:MODME_WORKTREES_ROOT)) {
+    if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+    if (-not [System.IO.Path]::IsPathRooted($candidate)) {
+      return (Join-Path $MainRepoRoot $candidate)
+    }
+    return $candidate
+  }
+
+  if (Test-Path "D:\") {
+    return (Join-Path "D:\Github_Projects\copilot-worktrees" $projectName)
+  }
+
+  return (Join-Path $MainRepoRoot ".worktrees")
+}
+
 function Get-WorktreeContext {
   param(
     [Parameter(Mandatory = $true)]
@@ -16,26 +38,23 @@ function Get-WorktreeContext {
   }
 
   $mainRepoRoot = (Resolve-Path (Split-Path -Parent $gitCommonDir)).Path
-  $worktreesRoot = Join-Path $mainRepoRoot ".worktrees"
+  $legacyWorktreesRoot = Join-Path $mainRepoRoot ".worktrees"
+  $worktreesRoot = Resolve-PreferredWorktreesRoot -MainRepoRoot $mainRepoRoot
   $repoRootResolved = (Resolve-Path $RepoRoot).Path
   $branch = (git -C $RepoRoot branch --show-current 2>$null).Trim()
-
-  $isWorktree = $false
-  if (Test-Path $worktreesRoot) {
-    $worktreesRootResolved = (Resolve-Path $worktreesRoot).Path
-    $isWorktree = $repoRootResolved.StartsWith($worktreesRootResolved, [StringComparison]::OrdinalIgnoreCase)
-  }
+  $isMainCheckout = ($repoRootResolved -eq $mainRepoRoot)
 
   [PSCustomObject]@{
-    RepoRoot       = $repoRootResolved
-    MainRepoRoot   = $mainRepoRoot
-    WorktreesRoot  = $worktreesRoot
-    DevCheckout    = Join-Path $worktreesRoot "dev"
-    IsWorktree     = $isWorktree
-    IsMainCheckout = ($repoRootResolved -eq $mainRepoRoot)
-    Branch         = $branch
+    RepoRoot           = $repoRootResolved
+    MainRepoRoot       = $mainRepoRoot
+    WorktreesRoot      = $worktreesRoot
+    LegacyWorktreesRoot = $legacyWorktreesRoot
+    DevCheckout        = Join-Path $worktreesRoot "dev"
+    IsWorktree         = (-not $isMainCheckout)
+    IsMainCheckout     = $isMainCheckout
+    Branch             = $branch
     # Legacy alias for scripts that still reference DevRootPath
-    DevRootPath    = $worktreesRoot
-    DevRootName    = ".worktrees"
+    DevRootPath        = $worktreesRoot
+    DevRootName        = Split-Path -Leaf $worktreesRoot
   }
 }

--- a/scripts/migrate-main-to-worktree.ps1
+++ b/scripts/migrate-main-to-worktree.ps1
@@ -33,16 +33,17 @@ Examples:
 }
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+. "$ScriptDir/lib/worktree-context.ps1"
 $RepoRoot = Split-Path -Parent $ScriptDir
-$ProjectName = Split-Path -Leaf $RepoRoot
-$ParentName = Split-Path -Leaf (Split-Path -Parent $RepoRoot)
-$ExpectedDevRoot = "${ProjectName}-dev"
+$ctx = Get-WorktreeContext -RepoRoot $RepoRoot
+$MainRepoRoot = $ctx.MainRepoRoot
+$WorktreesRoot = $ctx.WorktreesRoot
 
-if ($ParentName -eq $ExpectedDevRoot) {
-  Write-Error "Already in a worktree ($RepoRoot). Run from the main Monorepo_ModMe checkout."
+if ($ctx.IsWorktree) {
+  Write-Error "Already in a worktree ($($ctx.RepoRoot)). Run from the main Monorepo_ModMe checkout."
 }
 
-$status = git -C $RepoRoot status --porcelain
+$status = git -C $MainRepoRoot status --porcelain
 if ([string]::IsNullOrWhiteSpace($status)) {
   Write-Error "No uncommitted changes on main checkout. Use new-agent-worktree.ps1 instead."
 }
@@ -50,9 +51,8 @@ if ([string]::IsNullOrWhiteSpace($status)) {
 $Name = $Name.Trim().ToLower() -replace '\s+', '-'
 $BranchName = "feature/$Owner/$Name"
 $FolderName = if ($Owner -eq "human") { "dev-human-$Name" } else { "dev-agent-$Owner-$Name" }
-$DevWorktreeRoot = Join-Path (Split-Path -Parent $RepoRoot) $ExpectedDevRoot
-$TargetPath = Join-Path $DevWorktreeRoot $FolderName
-$CurrentBranch = git -C $RepoRoot branch --show-current
+$TargetPath = Join-Path $WorktreesRoot $FolderName
+$CurrentBranch = git -C $MainRepoRoot branch --show-current
 $stashMessage = "migrate-main-to-worktree-$Owner-$Name-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
 
 if (-not $FromCurrentBranch -and $CurrentBranch -ne "dev") {
@@ -62,8 +62,9 @@ if (-not $FromCurrentBranch -and $CurrentBranch -ne "dev") {
 Write-Host "===========================================" -ForegroundColor Cyan
 Write-Host "   MIGRATE MAIN TO WORKTREE" -ForegroundColor Cyan
 Write-Host "===========================================" -ForegroundColor Cyan
-Write-Host "   Main:       $RepoRoot"
+Write-Host "   Main:       $MainRepoRoot"
 Write-Host "   Branch:     $CurrentBranch"
+Write-Host "   Root:       $WorktreesRoot"
 Write-Host "   Target:     $TargetPath"
 Write-Host "   New branch: $BranchName"
 Write-Host "   From HEAD:  $FromCurrentBranch"
@@ -75,21 +76,21 @@ if (Test-Path $TargetPath) {
 
 function New-MigrateWorktree {
   if ($FromCurrentBranch) {
-    if (!(Test-Path $DevWorktreeRoot)) {
-      Write-Error "Dev worktree root not found at $DevWorktreeRoot. Run init-worktrees.ps1 first."
+    if (!(Test-Path $WorktreesRoot)) {
+      Write-Error "Worktree root not found at $WorktreesRoot. Run init-worktrees.ps1 first."
     }
     $branchExists = $false
     $prevEap = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
-    git -C $RepoRoot show-ref --verify --quiet "refs/heads/$BranchName" 2>$null | Out-Null
+    git -C $MainRepoRoot show-ref --verify --quiet "refs/heads/$BranchName" 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) { $branchExists = $true }
     $ErrorActionPreference = $prevEap
 
     if ($branchExists) {
-      git -C $RepoRoot worktree add $TargetPath $BranchName
+      git -C $MainRepoRoot worktree add $TargetPath $BranchName
     }
     else {
-      git -C $RepoRoot worktree add -b $BranchName $TargetPath HEAD
+      git -C $MainRepoRoot worktree add -b $BranchName $TargetPath HEAD
     }
     if ($LASTEXITCODE -ne 0) {
       throw "git worktree add failed for $TargetPath"
@@ -98,7 +99,7 @@ function New-MigrateWorktree {
     & "$ScriptDir/worktree-allocate-ports.ps1" -WorktreePath $TargetPath
     if ($LASTEXITCODE -ne 0) { throw "worktree-allocate-ports failed" }
 
-    & "$ScriptDir/worktree-copy-env.ps1" -SourceRoot $RepoRoot -TargetRoot $TargetPath
+    & "$ScriptDir/worktree-copy-env.ps1" -SourceRoot $MainRepoRoot -TargetRoot $TargetPath
     if ($LASTEXITCODE -ne 0) { throw "worktree-copy-env failed" }
 
     & "$ScriptDir/install-git-hooks.ps1"
@@ -126,7 +127,7 @@ if ($DryRun) {
 }
 
 Write-Host "Stashing uncommitted changes..." -ForegroundColor Cyan
-git -C $RepoRoot stash push -u -m $stashMessage
+git -C $MainRepoRoot stash push -u -m $stashMessage
 if ($LASTEXITCODE -ne 0) {
   Write-Error "git stash push failed"
 }
@@ -139,7 +140,7 @@ try {
   git -C $TargetPath stash pop
   if ($LASTEXITCODE -ne 0) {
     Write-Warning "stash pop reported conflicts or partial apply. Resolve under $TargetPath, then drop stash on main when done."
-    Write-Warning "Stash list: git -C `"$RepoRoot`" stash list"
+    Write-Warning "Stash list: git -C `"$MainRepoRoot`" stash list"
     exit $LASTEXITCODE
   }
 
@@ -155,6 +156,6 @@ try {
 }
 catch {
   Write-Warning "Migration failed - restoring stash on main checkout..."
-  git -C $RepoRoot stash pop 2>$null | Out-Null
+  git -C $MainRepoRoot stash pop 2>$null | Out-Null
   throw
 }

--- a/scripts/new-agent-worktree.ps1
+++ b/scripts/new-agent-worktree.ps1
@@ -24,7 +24,7 @@ Examples:
   .\scripts\new-agent-worktree.ps1 -Name "auth-fix" -Owner cursor
   .\scripts\new-agent-worktree.ps1 -Name "api-refactor" -Owner copilot
 
-Run .\scripts\init-worktrees.ps1 first if .worktrees/dev does not exist.
+Run .\scripts\init-worktrees.ps1 first if the worktree root does not exist.
 
 "@ -ForegroundColor Yellow
   exit 1
@@ -36,9 +36,11 @@ $prevDirenvDisable = $env:DIRENV_DISABLE
 $env:DIRENV_DISABLE = "1"
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+. "$ScriptDir/lib/worktree-context.ps1"
 $ProjectMainDir = Split-Path -Parent $ScriptDir
-$ProjectName = Split-Path -Leaf $ProjectMainDir
-$DevWorktreeRoot = Join-Path $ProjectMainDir ".worktrees"
+$ctx = Get-WorktreeContext -RepoRoot $ProjectMainDir
+$MainRepoRoot = $ctx.MainRepoRoot
+$DevWorktreeRoot = $ctx.WorktreesRoot
 
 try {
   Write-Host "===========================================" -ForegroundColor Cyan
@@ -47,6 +49,7 @@ try {
   Write-Host ""
   Write-Host "   Feature: $Name"
   Write-Host "   Owner:   $Owner"
+  Write-Host "   Root:    $DevWorktreeRoot"
   Write-Host ""
 
   function Check-Git {
@@ -79,17 +82,17 @@ try {
   $branchExists = $false
   $prevEap = $ErrorActionPreference
   $ErrorActionPreference = 'Continue'
-  git -C $ProjectMainDir show-ref --verify --quiet "refs/heads/$BranchName" 2>$null | Out-Null
+  git -C $MainRepoRoot show-ref --verify --quiet "refs/heads/$BranchName" 2>$null | Out-Null
   if ($LASTEXITCODE -eq 0) { $branchExists = $true }
   $ErrorActionPreference = $prevEap
 
   if ($branchExists) {
     Write-Host "   Branch exists. Attaching worktree..." -ForegroundColor Yellow
-    git -C $ProjectMainDir worktree add $TargetPath $BranchName
+    git -C $MainRepoRoot worktree add $TargetPath $BranchName
   }
   else {
     Write-Host "   Creating new branch from dev..." -ForegroundColor Yellow
-    git -C $ProjectMainDir worktree add -b $BranchName $TargetPath dev
+    git -C $MainRepoRoot worktree add -b $BranchName $TargetPath dev
   }
 
   if ($LASTEXITCODE -ne 0) {
@@ -101,7 +104,7 @@ try {
   if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   Write-Host "Copying .env files from main checkout..." -ForegroundColor Cyan
-  & "$ScriptDir/worktree-copy-env.ps1" -SourceRoot $ProjectMainDir -TargetRoot $TargetPath
+  & "$ScriptDir/worktree-copy-env.ps1" -SourceRoot $MainRepoRoot -TargetRoot $TargetPath
   if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   Write-Host "Installing git pre-commit hook..." -ForegroundColor Cyan

--- a/scripts/worktree-copy-env.ps1
+++ b/scripts/worktree-copy-env.ps1
@@ -46,10 +46,3 @@ foreach ($relativePath in $yarnBootstrapPaths) {
     Write-Host "   Copied $relativePath" -ForegroundColor Green
   }
 }
-
-$yarnDir = Join-Path $SourceRoot ".yarn"
-if (Test-Path $yarnDir) {
-  $targetYarn = Join-Path $TargetRoot ".yarn"
-  Copy-Item $yarnDir $targetYarn -Recurse -Force
-  Write-Host "   Copied .yarn/" -ForegroundColor Green
-}


### PR DESCRIPTION
## Summary
- Harden Copilot worktree bootstrap scripts
- Add lean-ctx workspace profiles doc
- Update orchestration docs / ignore / worktreeinclude

## Test plan
- [ ] Review script diffs for path safety
- [ ] Confirm docs/lean-ctx/workspace-profiles.md renders

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Copilot worktree bootstrap to use a predictable worktree root and safer script behavior, plus added `lean-ctx` workspace profiles and a session healthcheck. This improves reliability across machines (env overrides, D:\ SSD fallback) and updates docs/ignore to match.

- **New Features**
  - Worktree root resolution: `WORKTREES_ROOT` → `MODME_WORKTREES_ROOT` → `D:\Github_Projects\copilot-worktrees\<project>` → `<repo>\.worktrees`.
  - Cursor `sessionStart` runs `scripts/ensure-lean-ctx-config.ps1 -CheckOnly` (90s timeout) to validate `lean-ctx` setup.
  - Added `docs/lean-ctx/workspace-profiles.md`; updated orchestration guide with root resolution details.

- **Refactors**
  - Centralized path detection in `scripts/lib/worktree-context.ps1`; updated `init-worktrees.ps1`, `new-agent-worktree.ps1`, `migrate-main-to-worktree.ps1`, and `ensure-worktree.ps1`.
  - `IsWorktree` now means any non-main checkout (not tied to `.worktrees/`).
  - Stopped copying `.yarn/` into worktrees; still copy `.env` and lockfile bootstrap files; adjusted `.worktreeinclude`.
  - `.worktrees/` is now gitignored; `.serena/project.yml` refreshed to the latest schema defaults.

<sup>Written for commit 2c76e667fd50f9945e306e7b63b195444ebdbee8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ditto190/modme-ui-01/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

