### PR TITLE
docs(lean-ctx): workspace profiles on cautious-fortnight

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,40 +1,44 @@
-{
-  "hooks": {
-    "beforeSubmitPrompt": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor before-submit-prompt'"
-      }
-    ],
-    "preCompact": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor pre-compact'"
-      }
-    ],
-    "sessionEnd": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-end'"
-      }
-    ],
-    "sessionStart": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-start'"
-      }
-    ],
-    "stop": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor stop'"
-      }
-    ],
-    "subagentStart": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-start'"
-      }
-    ],
-    "subagentStop": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-stop'"
-      }
-    ]
-  },
-  "version": 1
+﻿{
+    "hooks":  {
+                  "beforeSubmitPrompt":  [
+                                             {
+                                                 "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor before-submit-prompt\u0027"
+                                             }
+                                         ],
+                  "preCompact":  [
+                                     {
+                                         "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor pre-compact\u0027"
+                                     }
+                                 ],
+                  "sessionEnd":  [
+                                     {
+                                         "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor session-end\u0027"
+                                     }
+                                 ],
+                  "stop":  [
+                               {
+                                   "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor stop\u0027"
+                               }
+                           ],
+                  "subagentStart":  [
+                                        {
+                                            "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor subagent-start\u0027"
+                                        }
+                                    ],
+                  "subagentStop":  [
+                                       {
+                                           "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor subagent-stop\u0027"
+                                       }
+                                   ],
+                  "sessionStart":  [
+                                       {
+                                           "command":  "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ensure-lean-ctx-config.ps1 -CheckOnly",
+                                           "timeout":  90
+                                       },
+                                       {
+                                           "command":  "sh -c \u0027if ! command -v entire \u003e/dev/null 2\u003e\u00261; then exit 0; fi; exec entire hooks cursor session-start\u0027"
+                                       }
+                                   ]
+              },
+    "version":  1
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ CI runs `node scripts/validate-changelog.mjs` on pull requests. See `docs/agent-
 ## [Unreleased]
 
 ### Added
+- (docs) lean-ctx workspace profiles on cautious-fortnight Copilot tree
 
 - (repo) Agent data plane — Entire CLI (`yarn entire:*`), Dolt sql-server (`yarn dolt:*`), KM hub (`yarn km:status`, `docs/KNOWLEDGE_QUICKSTART.md`, `docs/knowledge/CATALOG.md`), ADR-0013 superseding ADR-0010
 - (repo) KM session startup wiring — `scripts/km-session-bootstrap.ps1` (`yarn km:bootstrap`), session start + worktree setup + VS Code tasks/launch (`Full Stack: Forge Core + Agent Data Plane`, soft `dependsOn` on `next-forge: dev core`); ADR-0014; beads `modme-awz`; runbook `docs/monorepo/km-agent-data-plane-startup.md`

--- a/docs/lean-ctx/workspace-profiles.md
+++ b/docs/lean-ctx/workspace-profiles.md
@@ -1,0 +1,46 @@
+# Github_Projects lean-ctx workspace profiles
+
+## Config tiers
+
+1. **Env vars** (`LEAN_CTX_*`) — highest
+2. **Project** `<repo>/.lean-ctx.toml`
+3. **D: workspace global** `D:\Github_Projects\.config\lean-ctx\config.toml` when `LEAN_CTX_CONFIG_DIR` is set (via [Github_Projects.code-workspace](../../Github_Projects.code-workspace))
+4. **C: user global** `~\.config\lean-ctx\config.toml` when workspace env is unset
+
+## Session automation
+
+| Trigger | Script |
+| --- | --- |
+| Cursor `sessionStart` (workspace hooks) | `scripts/github-projects-healthcheck.ps1` |
+| Integrated terminal profile `GP PowerShell (lean-ctx)` | `scripts/github-projects-session-bootstrap.ps1` |
+
+Bootstrap runs once per calendar day (marker under `.cursor/hooks/state/`). Use `-Force` to re-run.
+
+## Activate a skill-aligned profile
+
+```powershell
+$env:LEAN_CTX_PROFILE = "powershell-windows"   # or ai-native-cli, windows-shell-reliability, bash-shell, os-scripting
+$env:LEAN_CTX_PERSONA = "powershell-windows"
+# list: lean-ctx profile list
+```
+
+| Profile / persona | Skill alignment |
+| --- | --- |
+| `powershell-windows` | powershell-windows |
+| `windows-shell-reliability` | windows-shell-reliability |
+| `ai-native-cli` | ai-native-cli |
+| `bash-shell` | bash / shell |
+| `os-scripting` | os-scripting |
+| `shell` (persona only) | /shell |
+
+Personas: `.config/lean-ctx/personas/`. Context profiles: `.local/share/lean-ctx/profiles/` (when `LEAN_CTX_DATA_DIR` points at the D: workspace).
+
+## Verify
+
+```powershell
+$env:LEAN_CTX_CONFIG_DIR = "D:\Github_Projects\.config\lean-ctx"
+lean-ctx config validate
+lean-ctx doctor
+.\scripts\github-projects-healthcheck.ps1 -Json
+.\scripts\github-projects-session-bootstrap.ps1 -Force
+```


### PR DESCRIPTION
## Summary
- Add lean-ctx workspace profiles
- Align Cursor hooks on cautious-fortnight Copilot tree

## Test plan
- [ ] Confirm docs present

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `lean-ctx` workspace profiles for the cautious-fortnight Copilot worktree and updates `Cursor` session hooks to validate `lean-ctx` config on startup.

- **New Features**
  - Added `docs/lean-ctx/workspace-profiles.md` with config tiers, profile/persona activation, and verify steps.
  - Updated `.cursor/hooks.json` to run `scripts/ensure-lean-ctx-config.ps1 -CheckOnly` on `sessionStart` (90s timeout) before the `entire` session-start hook.

<sup>Written for commit 7da2bd0c36b2dba2ab3be3cff294f6fce74ed409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ditto190/modme-ui-01/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

