### PR TITLE
fix(dx): silent terminal attach and non-blocking chat/beads probes

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,8 +1,11 @@
 {
+  "version": 1,
   "hooks": {
     "beforeSubmitPrompt": [
       {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor before-submit-prompt'"
+        "command": "sh -c 'if [ \"${MODME_ENTIRE_SUBMIT_HOOK:-}\" != \"1\" ]; then exit 0; fi; if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor before-submit-prompt'",
+        "failClosed": false,
+        "timeoutSec": 2
       }
     ],
     "preCompact": [
@@ -10,17 +13,44 @@
         "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor pre-compact'"
       }
     ],
-    "sessionEnd": [
-      {
-        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-end'"
-      }
-    ],
     "sessionStart": [
+      {
+        "command": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ensure-lean-ctx-config.ps1 -CheckOnly",
+        "failClosed": false,
+        "timeoutSec": 5
+      },
+      {
+        "command": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/km-session-bootstrap.ps1",
+        "failClosed": false,
+        "timeoutSec": 90
+      },
       {
         "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-start'"
       }
     ],
+    "sessionEnd": [
+      {
+        "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .cursor/hooks/session-beads-dolt-sync.ps1",
+        "failClosed": false,
+        "timeoutSec": 60
+      },
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-end'"
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .cursor/hooks/lean-ctx-post-edit.ps1",
+        "failClosed": false,
+        "timeoutSec": 3
+      }
+    ],
     "stop": [
+      {
+        "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .cursor/hooks/lean-ctx-stop-marker.ps1",
+        "failClosed": false,
+        "timeoutSec": 3
+      },
       {
         "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor stop'"
       }
@@ -35,6 +65,5 @@
         "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-stop'"
       }
     ]
-  },
-  "version": 1
+  }
 }

--- a/.cursor/hooks/session-beads-dolt-sync.ps1
+++ b/.cursor/hooks/session-beads-dolt-sync.ps1
@@ -1,0 +1,125 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  H3 sessionEnd: beads↔Dolt sync + optional Entire checkpoint (fail-open).
+
+.DESCRIPTION
+  Adapts awesome-copilot session-auto-commit ideas WITHOUT git add -A / --no-verify.
+  Default: yarn beads:push. Optional guarded WIP commit when MODME_SESSION_AUTO_COMMIT=1
+  and cwd is a worktree (not main checkout). Governance (secrets → license → audit) gates WIP.
+#>
+param(
+  [switch]$SkipBeadsPush,
+  [switch]$Help
+)
+
+$ErrorActionPreference = 'Continue'
+
+if ($Help) {
+  @'
+session-beads-dolt-sync — Cursor sessionEnd hook (fail-open)
+
+  1. yarn beads:push (Dolt sync)
+  2. entire checkpoint if CLI present
+  3. Optional WIP git commit only if MODME_SESSION_AUTO_COMMIT=1 and in a worktree
+     (after .github/hooks/session-governance — never git add -A, never --no-verify)
+'@
+  exit 0
+}
+
+$HookDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $HookDir)
+if (-not (Test-Path -LiteralPath (Join-Path $RepoRoot 'package.json'))) {
+  $RepoRoot = (Get-Location).Path
+}
+
+Set-Location $RepoRoot
+
+$stateDir = Join-Path $RepoRoot '.cursor\hooks\state'
+New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+$log = Join-Path $stateDir 'session-beads-dolt-sync.jsonl'
+
+function Write-SyncLog([string]$Event, [hashtable]$Extra = @{}) {
+  $row = @{ at = (Get-Date).ToUniversalTime().ToString('o'); event = $Event }
+  foreach ($k in $Extra.Keys) { $row[$k] = $Extra[$k] }
+  ($row | ConvertTo-Json -Compress) | Add-Content -Path $log -Encoding utf8
+}
+
+Write-SyncLog 'start'
+
+# 1. Beads → Dolt
+if (-not $SkipBeadsPush) {
+  if (Get-Command yarn -ErrorAction SilentlyContinue) {
+    Write-Host '[session-sync] yarn beads:push…' -ForegroundColor Cyan
+    yarn beads:push 2>&1 | Out-Host
+    Write-SyncLog 'beads-push' @{ exit = $LASTEXITCODE }
+  }
+  else {
+    Write-SyncLog 'beads-push' @{ skipped = $true; reason = 'yarn missing' }
+  }
+}
+
+# 2. Entire checkpoint (best-effort)
+if (Get-Command entire -ErrorAction SilentlyContinue) {
+  try {
+    entire checkpoint 2>&1 | Out-Null
+    Write-SyncLog 'entire-checkpoint' @{ ok = $true }
+  }
+  catch {
+    Write-SyncLog 'entire-checkpoint' @{ ok = $false; err = "$_" }
+  }
+}
+
+# 3. Optional guarded WIP commit (never --no-verify, never on main checkout)
+if ($env:MODME_SESSION_AUTO_COMMIT -eq '1') {
+  $inWorktree = $false
+  try {
+    $common = git -C $RepoRoot rev-parse --git-common-dir 2>$null
+    $gitDir = git -C $RepoRoot rev-parse --git-dir 2>$null
+    if ($common -and $gitDir -and ($common -ne $gitDir) -and ($common -ne '.')) {
+      $inWorktree = $true
+    }
+    $leaf = Split-Path -Leaf $RepoRoot
+    if ($RepoRoot -match '[\\/]\.worktrees[\\/]' -or $leaf -match '^dev-agent-') {
+      $inWorktree = $true
+    }
+  }
+  catch { }
+
+  if (-not $inWorktree) {
+    Write-SyncLog 'wip-commit' @{ skipped = $true; reason = 'not a worktree' }
+  }
+  else {
+    $status = git -C $RepoRoot status --porcelain 2>$null
+    if (-not $status) {
+      Write-SyncLog 'wip-commit' @{ skipped = $true; reason = 'clean tree' }
+    }
+    else {
+      $govScript = Join-Path $RepoRoot '.github\hooks\session-governance\Invoke-SessionGovernance.ps1'
+      if (Test-Path -LiteralPath $govScript) {
+        Write-Host '[session-sync] governance gates…' -ForegroundColor Cyan
+        & pwsh -NoProfile -ExecutionPolicy Bypass -File $govScript
+        $govExit = $LASTEXITCODE
+        Write-SyncLog 'governance' @{ exit = $govExit }
+        if ($govExit -ne 0) {
+          Write-SyncLog 'wip-commit' @{ skipped = $true; reason = 'governance-blocked' }
+          Write-Host '[session-sync] WIP skipped (governance blocked)' -ForegroundColor Yellow
+          Write-SyncLog 'done'
+          exit 0
+        }
+      }
+      else {
+        Write-SyncLog 'governance' @{ skipped = $true; reason = 'missing Invoke-SessionGovernance.ps1' }
+      }
+
+      $msg = "chore(session): WIP checkpoint $(Get-Date -Format 'yyyy-MM-dd HH:mm')"
+      # Explicit tracked updates only — never git add -A; hooks always run
+      git -C $RepoRoot add -u -- . 2>$null
+      git -C $RepoRoot commit -m $msg 2>&1 | Out-Host
+      Write-SyncLog 'wip-commit' @{ exit = $LASTEXITCODE; msg = $msg }
+    }
+  }
+}
+
+Write-SyncLog 'done'
+exit 0

--- a/scripts/install-pwsh-terminal-hooks.ps1
+++ b/scripts/install-pwsh-terminal-hooks.ps1
@@ -1,19 +1,55 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-  Patch PowerShell profile: safe direnv hook, Cursor/VS Code shell integration, oh-my-posh guard.
+  Patch PowerShell profiles: safe direnv hook, Cursor/VS Code shell integration, Devbox guard.
 .DESCRIPTION
-  Idempotent markers in $PROFILE (pwsh). Run from repo root after clone or when terminal shows
-  profile errors (code not found, Invoke-Expression direnv, shell integration).
+  Idempotent markers in CurrentUser profiles for both Windows PowerShell 5.1 and pwsh 7+.
+  Covers OneDrive-redirected Documents paths. Run from repo root after clone or when
+  `devbox` / direnv / shell-integration errors appear in the integrated terminal.
+
+  Jetify Devbox is optional and WSL-only on this machine. The profile guard prevents
+  CommandNotFoundException when agents or humans type `devbox shell` in Windows PowerShell.
 #>
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Get-PwshProfilePath {
-  if (Get-Command pwsh -ErrorAction SilentlyContinue) {
-    return (pwsh -NoProfile -Command 'Write-Output $PROFILE').Trim()
+function Get-HostProfilePath {
+  param(
+    [ValidateSet('pwsh', 'powershell')]
+    [string]$HostName
+  )
+  if ($HostName -eq 'pwsh') {
+    if (-not (Get-Command pwsh -ErrorAction SilentlyContinue)) { return $null }
+    return (pwsh -NoProfile -Command 'Write-Output $PROFILE.CurrentUserCurrentHost').Trim()
   }
-  return $PROFILE
+  if (-not (Get-Command powershell.exe -ErrorAction SilentlyContinue)) { return $null }
+  return (powershell.exe -NoProfile -Command 'Write-Output $PROFILE.CurrentUserCurrentHost').Trim()
+}
+
+function Get-ModMeProfilePaths {
+  $paths = New-Object System.Collections.Generic.List[string]
+  foreach ($hostName in @('pwsh', 'powershell')) {
+    $resolved = Get-HostProfilePath -HostName $hostName
+    if ($resolved) { [void]$paths.Add($resolved) }
+  }
+  $relatives = @(
+    'Documents\PowerShell\Microsoft.PowerShell_profile.ps1',
+    'Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1',
+    'OneDrive\Documents\PowerShell\Microsoft.PowerShell_profile.ps1',
+    'OneDrive\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1'
+  )
+  foreach ($rel in $relatives) {
+    [void]$paths.Add((Join-Path $env:USERPROFILE $rel))
+  }
+  return @($paths | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+}
+
+function Backup-ModMeProfile {
+  param([string]$ProfilePath)
+  if (-not (Test-Path -LiteralPath $ProfilePath)) { return }
+  $bak = "$ProfilePath.modme.bak"
+  Copy-Item -LiteralPath $ProfilePath -Destination $bak -Force
+  Write-Host "[ok] backup -> $bak"
 }
 
 $markerStart = '# >>> Monorepo_ModMe terminal hooks >>>'
@@ -21,7 +57,7 @@ $markerEnd = '# <<< Monorepo_ModMe terminal hooks <<<'
 
 $hookBlock = @"
 $markerStart
-# Managed by scripts/install-pwsh-terminal-hooks.ps1 — safe direnv + editor shell integration
+# Managed by scripts/install-pwsh-terminal-hooks.ps1 - safe direnv + editor shell integration + Devbox guard
 
 function Import-EditorShellIntegration {
   if (`$env:__EditorShellIntegrationImported) { return }
@@ -64,7 +100,9 @@ foreach (`$dir in @(`$env:DIRENV_CONFIG, `$env:XDG_CACHE_HOME, `$env:XDG_DATA_HO
 if (Test-Path `$wingetDirenvDir) {
   `$env:Path = "`$wingetDirenvDir;`$env:Path"
 }
-if (`$PSVersionTable.PSVersion.Major -ge 7 -and (Get-Command direnv -ErrorAction SilentlyContinue)) {
+# direnv/.envrc is for WSL/Git Bash/devcontainer - not native Windows (use yarn session:start).
+`$enableDirenv = (`$env:MODME_ENABLE_DIRENV -eq '1') -or (`$env:WSL_DISTRO_NAME) -or (`$IsLinux -eq `$true)
+if (`$enableDirenv -and `$PSVersionTable.PSVersion.Major -ge 7 -and (Get-Command direnv -ErrorAction SilentlyContinue)) {
   try {
     `$direnvHook = (direnv hook pwsh 2>`$null | Out-String).Trim()
     if (`$direnvHook) {
@@ -77,6 +115,91 @@ if (`$PSVersionTable.PSVersion.Major -ge 7 -and (Get-Command direnv -ErrorAction
   catch {
     Write-Warning "direnv hook skipped: `$_"
   }
+}
+
+# ModMe soft-attach: KM / agent plane health (fail-open; never creates beads/mprocs)
+function Invoke-ModMeTerminalAttach {
+  if (`$env:MODME_TERMINAL_ATTACHED -eq '1') { return }
+  if (`$env:MODME_SKIP_TERMINAL_ATTACH -eq '1') { return }
+  `$candidates = @()
+  if (`$env:MODME_REPO_ROOT) { `$candidates += `$env:MODME_REPO_ROOT }
+  `$cwd = (Get-Location).Path
+  `$dir = `$cwd
+  if (-not [string]::IsNullOrWhiteSpace(`$dir)) {
+    for (`$i = 0; `$i -lt 24; `$i++) {
+      if ([string]::IsNullOrWhiteSpace(`$dir)) { break }
+      if ((Test-Path (Join-Path `$dir 'scripts\modme-terminal-attach.ps1'))) {
+        `$candidates += `$dir
+        break
+      }
+      `$parent = Split-Path -Parent `$dir
+      if ([string]::IsNullOrWhiteSpace(`$parent) -or `$parent -eq `$dir) { break }
+      `$dir = `$parent
+    }
+  }
+  `$candidates += 'D:\Github_Projects\Monorepo_ModMe'
+  foreach (`$root in `$candidates) {
+    if ([string]::IsNullOrWhiteSpace(`$root)) { continue }
+    `$attach = Join-Path `$root 'scripts\modme-terminal-attach.ps1'
+    if (Test-Path -LiteralPath `$attach) {
+      try {
+        & `$attach
+        `$env:MODME_TERMINAL_ATTACHED = '1'
+      }
+      catch { }
+      return
+    }
+  }
+}
+Invoke-ModMeTerminalAttach
+
+# Jetify Devbox is WSL-only for ModMe. Guard prevents CommandNotFoundException on Windows.
+function global:Invoke-ModMeDevboxGuard {
+  [CmdletBinding()]
+  param(
+    [Parameter(ValueFromRemainingArguments = `$true)]
+    [object[]]`$DevboxArgs
+  )
+
+  `$native = Get-Command -Name devbox -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (`$native) {
+    if (`$null -eq `$DevboxArgs -or `$DevboxArgs.Count -eq 0) {
+      & `$native.Source
+    }
+    else {
+      & `$native.Source @DevboxArgs
+    }
+    return
+  }
+
+  Write-Host '[!] Jetify Devbox is not on Windows PATH (expected for ModMe).' -ForegroundColor Yellow
+  Write-Host '[i] Prefer Windows yarn/agent tooling:' -ForegroundColor Cyan
+  Write-Host '    yarn session:start' -ForegroundColor Gray
+  Write-Host '    yarn agent:status' -ForegroundColor Gray
+  Write-Host '    yarn test:shell' -ForegroundColor Gray
+  Write-Host '[i] For a real Devbox shell, use WSL modme-agent:' -ForegroundColor Cyan
+  Write-Host '    wsl -d Ubuntu -u modme-agent' -ForegroundColor Gray
+  Write-Host '    cd /mnt/d/Github_Projects/Monorepo_ModMe' -ForegroundColor Gray
+  Write-Host '    devbox shell' -ForegroundColor Gray
+  Write-Host '[i] Optional WSL proxy: `$env:MODME_DEVBOX_WSL_PROXY = ''1''' -ForegroundColor DarkGray
+
+  if (`$env:MODME_DEVBOX_WSL_PROXY -ne '1') { return }
+
+  `$repo = if (`$env:MODME_REPO_ROOT) { `$env:MODME_REPO_ROOT } else { 'D:\Github_Projects\Monorepo_ModMe' }
+  if (`$repo -match '^[A-Za-z]:') {
+    `$drive = `$repo.Substring(0, 1).ToLowerInvariant()
+    `$unix = '/mnt/' + `$drive + (`$repo.Substring(2) -replace '\\', '/')
+  }
+  else {
+    `$unix = `$repo -replace '\\', '/'
+  }
+  `$argText = if (`$null -eq `$DevboxArgs -or `$DevboxArgs.Count -eq 0) { 'shell' } else { (`$DevboxArgs | ForEach-Object { `$_.ToString() }) -join ' ' }
+  `$bash = "cd '`$unix' && /home/modme-agent/.local/bin/devbox `$argText"
+  & wsl.exe -d Ubuntu -u modme-agent -- bash -lc `$bash
+}
+
+if (-not (Get-Command -Name devbox -CommandType Application -ErrorAction SilentlyContinue)) {
+  Set-Item -Path 'Function:global:devbox' -Value `${function:Invoke-ModMeDevboxGuard}
 }
 $markerEnd
 "@
@@ -101,7 +224,7 @@ function Set-CondaProfileBlock {
 
 #region conda initialize
 # !! Contents within this block are managed by conda / install-pwsh-terminal-hooks.ps1 !!
-# Uses conda-hook.ps1 (module only) — avoids broken "conda activate base" on pwsh 7.6 + conda 23.x
+# Uses conda-hook.ps1 (module only) - avoids broken "conda activate base" on pwsh 7.6 + conda 23.x
 If (Test-Path "$condaHookScript") {
     . "$condaHookScript"
 }
@@ -124,6 +247,8 @@ function Set-ProfileHookBlock {
   $dir = Split-Path $ProfilePath -Parent
   if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
   if (-not (Test-Path $ProfilePath)) { New-Item -ItemType File -Force -Path $ProfilePath | Out-Null }
+
+  Backup-ModMeProfile -ProfilePath $ProfilePath
 
   $content = Get-Content -Path $ProfilePath -Raw -ErrorAction SilentlyContinue
   if ($null -eq $content) { $content = '' }
@@ -151,26 +276,21 @@ function Set-ProfileHookBlock {
   Set-Content -Path $ProfilePath -Value $content -Encoding UTF8
 }
 
-$pwshProfile = Get-PwshProfilePath
-Set-ProfileHookBlock $pwshProfile
+$profilePaths = Get-ModMeProfilePaths
+Write-Host '[i] Patching PowerShell profiles:' -ForegroundColor Cyan
+foreach ($profilePath in $profilePaths) {
+  Write-Host "    $profilePath"
+  Set-ProfileHookBlock $profilePath
 
-# CurrentUserAllHosts — conda init lives here and loads BEFORE Microsoft.PowerShell_profile.ps1
-$allHostsProfile = Join-Path (Split-Path $pwshProfile -Parent) 'profile.ps1'
-if (Test-Path $allHostsProfile) {
-  Set-CondaProfileBlock $allHostsProfile
-}
-
-# Also patch Documents profile if different (OneDrive sync path)
-$docsProfile = Join-Path $env:USERPROFILE 'Documents\PowerShell\Microsoft.PowerShell_profile.ps1'
-if ((Test-Path $docsProfile) -and ($docsProfile -ne $pwshProfile)) {
-  Set-ProfileHookBlock $docsProfile
-}
-
-$docsAllHosts = Join-Path $env:USERPROFILE 'Documents\PowerShell\profile.ps1'
-if ((Test-Path $docsAllHosts) -and ($docsAllHosts -ne $allHostsProfile)) {
-  Set-CondaProfileBlock $docsAllHosts
+  $allHostsProfile = Join-Path (Split-Path $profilePath -Parent) 'profile.ps1'
+  if (Test-Path $allHostsProfile) {
+    Set-CondaProfileBlock $allHostsProfile
+  }
 }
 
 Write-Host ''
-Write-Host 'Restart pwsh or open a new terminal. Verify with:'
-Write-Host '  pwsh -NoLogo -Command "Write-Host ok; `$PSVersionTable.PSVersion"'
+Write-Host 'Restart the integrated terminal (or open a new one). Verify with:'
+Write-Host '  powershell -NoLogo -Command "devbox shell"'
+Write-Host '  pwsh -NoLogo -Command "devbox shell"'
+Write-Host 'Expect a ModMe guard message (not CommandNotFoundException).'
+Write-Host 'Native Windows PATH still has no Jetify Devbox; use yarn:* or WSL modme-agent.'

--- a/scripts/km-session-bootstrap.ps1
+++ b/scripts/km-session-bootstrap.ps1
@@ -67,7 +67,7 @@ Write-Host 'KM session bootstrap (agent data plane)...' -ForegroundColor Cyan
 
 # 1. Refresh PATH so winget/scoop installs are visible in this process
 $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' +
-  [System.Environment]::GetEnvironmentVariable('Path', 'User')
+[System.Environment]::GetEnvironmentVariable('Path', 'User')
 
 # 2. Optional Beads ↔ sql-server env hints
 $beadsServerEnv = Join-Path $RepoRoot '.dolt-data\beads-server.env'
@@ -120,32 +120,70 @@ if (-not $SkipEntire) {
   }
 }
 
-# 5. Beads ready (read-only check)
+# 5. Beads ready (read-only check) — prefer global bd; timeout so npx never hangs the shell
 if (-not $SkipBeads) {
   Write-KmInfo 'Checking beads ready...'
-  if (Get-Command npx -ErrorAction SilentlyContinue) {
-    $prevEap = $ErrorActionPreference
-    $ErrorActionPreference = 'Continue'
-    $bdOut = & npx --yes @beads/bd ready 2>&1
-    $bdCode = $LASTEXITCODE
-    $ErrorActionPreference = $prevEap
-    $bdText = ($bdOut | Out-String)
-    if ($bdText -match 'Error 1105|auto-backup failed|table file not found') {
-      Write-KmWarn 'Beads auto-backup noise detected — see docs/beads-workflow.md (backup.enabled)'
+  $bdTimeoutSec = 20
+
+  function Resolve-BeadsReadyInvocation {
+    $bd = Get-Command bd -ErrorAction SilentlyContinue
+    if ($bd -and $bd.CommandType -eq 'Application') {
+      return @{ File = $bd.Source; Args = @('ready') }
     }
-    if ($bdCode -ne 0) {
-      Write-Host $bdText
-      Set-KmFailed "bd ready failed (exit $bdCode)"
+    # Prefer npx.cmd — Start-Process cannot run npx.ps1 ("%1 is not a valid Win32 application")
+    $npxCmd = Join-Path $env:ProgramFiles 'nodejs\npx.cmd'
+    if (-not (Test-Path -LiteralPath $npxCmd)) {
+      $npx = Get-Command npx.cmd -ErrorAction SilentlyContinue
+      if ($npx) { $npxCmd = $npx.Source }
+      else { $npxCmd = $null }
     }
-    else {
-      Write-KmOk 'Beads ready OK'
-      if ($bdText.Trim()) {
-        Write-Host ($bdText.Trim() -split "`n" | Select-Object -First 12) -ForegroundColor DarkGray
-      }
+    if ($npxCmd -and (Test-Path -LiteralPath $npxCmd)) {
+      return @{ File = $npxCmd; Args = @('--yes', '@beads/bd', 'ready') }
     }
+    return $null
+  }
+
+  $inv = Resolve-BeadsReadyInvocation
+  if (-not $inv) {
+    Set-KmFailed 'bd/npx.cmd not on PATH — cannot run bd ready'
   }
   else {
-    Set-KmFailed 'npx not on PATH — cannot run bd ready'
+    $outFile = [System.IO.Path]::GetTempFileName()
+    $errFile = [System.IO.Path]::GetTempFileName()
+    try {
+      $proc = Start-Process -FilePath $inv.File -ArgumentList $inv.Args `
+        -NoNewWindow -PassThru `
+        -RedirectStandardOutput $outFile -RedirectStandardError $errFile
+      if (-not $proc.WaitForExit($bdTimeoutSec * 1000)) {
+        try { $proc.Kill() } catch { }
+        Set-KmFailed "bd ready timed out after ${bdTimeoutSec}s (silent attach will retry later)"
+      }
+      else {
+        $bdCode = $proc.ExitCode
+        if ($null -eq $bdCode) { $bdCode = 0 }
+        $bdText = ((Get-Content -LiteralPath $outFile -Raw -ErrorAction SilentlyContinue) + "`n" +
+          (Get-Content -LiteralPath $errFile -Raw -ErrorAction SilentlyContinue))
+        if ($bdText -match 'Error 1105|auto-backup failed|table file not found') {
+          Write-KmWarn 'Beads auto-backup noise detected — see docs/beads-workflow.md (backup.enabled)'
+        }
+        if ([int]$bdCode -ne 0) {
+          Write-Host $bdText
+          Set-KmFailed "bd ready failed (exit $bdCode)"
+        }
+        else {
+          Write-KmOk 'Beads ready OK'
+          if ($bdText.Trim()) {
+            Write-Host ($bdText.Trim() -split "`n" | Select-Object -First 12) -ForegroundColor DarkGray
+          }
+        }
+      }
+    }
+    catch {
+      Set-KmFailed "bd ready invoke failed: $_"
+    }
+    finally {
+      Remove-Item -LiteralPath $outFile, $errFile -Force -ErrorAction SilentlyContinue
+    }
   }
 }
 

--- a/scripts/modme-terminal-attach.ps1
+++ b/scripts/modme-terminal-attach.ps1
@@ -1,0 +1,148 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Terminal-attach health for the agent data plane (H2).
+
+.DESCRIPTION
+  Fail-open probe called from PowerShell profile / integrated terminal open.
+  Soft-fixes lean-ctx config and runs km-session-bootstrap (non-strict).
+
+  By default this is silent and non-blocking: stamp debounce immediately, then
+  spawn a background PowerShell that writes to the jsonl/log only so the
+  interactive prompt is never held by beads/npx/km:status.
+#>
+param(
+  [switch]$Force,
+  [switch]$Foreground,
+  [int]$DebounceMinutes = 30,
+  [switch]$Help
+)
+
+$ErrorActionPreference = 'Continue'
+
+if ($Help) {
+  @'
+modme-terminal-attach — KM / agent plane health on terminal open (fail-open, silent)
+
+  1. Debounce (default 30m) via .cursor/hooks/state/modme-terminal-attach.stamp
+  2. Stamp immediately (prevents concurrent shells from stacking)
+  3. Background: yarn lean-ctx:ensure -CheckOnly + km-session-bootstrap (non-strict)
+     Logs: .cursor/hooks/state/modme-terminal-attach.jsonl (+ .log for child stdout)
+
+  -Foreground  Run probes in this shell (verbose; for debugging)
+  -Force       Ignore debounce
+  MODME_SKIP_TERMINAL_ATTACH=1  Skip entirely (profile guard)
+'@
+  exit 0
+}
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$RepoRoot = Split-Path -Parent $ScriptDir
+
+# Guard: empty $RepoRoot would break Join-Path (seen in broken profiles)
+if (-not $RepoRoot -or -not (Test-Path -LiteralPath $RepoRoot)) {
+  exit 0
+}
+
+$stateDir = Join-Path $RepoRoot '.cursor\hooks\state'
+New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+$stamp = Join-Path $stateDir 'modme-terminal-attach.stamp'
+$log = Join-Path $stateDir 'modme-terminal-attach.jsonl'
+$childLog = Join-Path $stateDir 'modme-terminal-attach.bg.log'
+
+if (-not $Force -and (Test-Path -LiteralPath $stamp)) {
+  try {
+    $age = (Get-Date) - (Get-Item -LiteralPath $stamp).LastWriteTime
+    if ($age.TotalMinutes -lt $DebounceMinutes) {
+      exit 0
+    }
+  }
+  catch { }
+}
+
+function Write-AttachLog([string]$Event, [hashtable]$Extra = @{}) {
+  $row = @{
+    at    = (Get-Date).ToUniversalTime().ToString('o')
+    event = $Event
+    repo  = $RepoRoot
+  }
+  foreach ($k in $Extra.Keys) { $row[$k] = $Extra[$k] }
+  try {
+    ($row | ConvertTo-Json -Compress) | Add-Content -Path $log -Encoding utf8
+  }
+  catch { }
+}
+
+# Stamp first so parallel terminals debounce instead of all hanging on bd ready.
+Set-Content -Path $stamp -Value ((Get-Date).ToUniversalTime().ToString('o')) -Encoding utf8
+Write-AttachLog 'start' @{ mode = $(if ($Foreground) { 'foreground' } else { 'background' }) }
+
+$leanEnsure = Join-Path $ScriptDir 'ensure-lean-ctx-config.ps1'
+$km = Join-Path $ScriptDir 'km-session-bootstrap.ps1'
+
+function Invoke-ModMeAttachProbes {
+  Set-Location $RepoRoot
+  if (Test-Path -LiteralPath $leanEnsure) {
+    try {
+      & $leanEnsure -CheckOnly 2>&1 | Out-Null
+      Write-AttachLog 'lean-ctx-check' @{ ok = $true }
+    }
+    catch {
+      Write-AttachLog 'lean-ctx-check' @{ ok = $false; err = "$_" }
+    }
+  }
+
+  if (Test-Path -LiteralPath $km) {
+    try {
+      # Full bootstrap (incl. beads) only in this silent/background child — never on the interactive prompt.
+      & $km 2>&1 | Out-Null
+      Write-AttachLog 'km-bootstrap' @{ exit = $LASTEXITCODE }
+    }
+    catch {
+      Write-AttachLog 'km-bootstrap' @{ ok = $false; err = "$_" }
+    }
+  }
+  else {
+    Write-AttachLog 'km-bootstrap' @{ ok = $false; err = 'km-session-bootstrap.ps1 missing' }
+  }
+
+  Write-AttachLog 'done'
+}
+
+if ($Foreground) {
+  Write-Host '[modme-terminal-attach] agent plane health (foreground)…' -ForegroundColor Cyan
+  Invoke-ModMeAttachProbes
+  exit 0
+}
+
+# Silent background update — never block the interactive prompt.
+$psExe = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+if (-not (Test-Path -LiteralPath $psExe)) {
+  $psExe = 'powershell.exe'
+}
+
+$argList = @(
+  '-NoProfile',
+  '-ExecutionPolicy', 'Bypass',
+  '-WindowStyle', 'Hidden',
+  '-File', "`"$($MyInvocation.MyCommand.Path)`"",
+  '-Force',
+  '-Foreground'
+)
+
+try {
+  $errLog = Join-Path $stateDir 'modme-terminal-attach.bg.err.log'
+  Start-Process -FilePath $psExe -ArgumentList $argList -WorkingDirectory $RepoRoot `
+    -WindowStyle Hidden `
+    -RedirectStandardOutput $childLog `
+    -RedirectStandardError $errLog `
+    -ErrorAction Stop | Out-Null
+  Write-AttachLog 'spawned' @{ log = $childLog; errLog = $errLog }
+}
+catch {
+  # Last resort: run probes inline but still quiet (no Host spam).
+  Write-AttachLog 'spawn-failed' @{ err = "$_" }
+  Invoke-ModMeAttachProbes
+}
+
+exit 0


### PR DESCRIPTION
## Summary
- Gate Entire `beforeSubmitPrompt` behind `MODME_ENTIRE_SUBMIT_HOOK=1` with `failClosed: false` and a 2s timeout so chat Send no longer freezes.
- Make `modme-terminal-attach` stamp+spawn silently in the background so integrated terminals get a prompt immediately.
- Harden `bd ready` with a 20s timeout using `npx.cmd` (not `npx.ps1`) to avoid hung shells and Win32 `%1` errors.
- Wire sessionEnd beads/Dolt sync hook without vendor `git add -A` / `--no-verify`.

## Why
Cursor chat freezes on every send and new terminals hung on `Checking beads ready...` after Entire checks. Windows NIC teaming was a red herring; the blockers were synchronous hooks and `npx.ps1` via `Start-Process`.

## Verification
- [x] `modme-terminal-attach.ps1` returns in ~150–300ms (background spawn)
- [x] `km-session-bootstrap.ps1 -SkipDolt -SkipEntire -SkipStatus` → Beads ready OK / KM bootstrap OK
- [x] Pre-push audit scoped to these DX files only (unrelated WIP left unstaged on other branch)
- [ ] Reload Cursor and confirm chat Send no longer freezes
- [ ] Open a new integrated terminal and confirm prompt appears without beads hang

## Checklist
- [x] Focused PR (no unrelated monorepo WIP)
- [x] No secrets in diff
- [x] Targets `dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Cursor chat send from freezing and fixes new terminal hangs by making hooks fail-open, adding short timeouts, and moving terminal attach/health checks to the background. Also adds a session-end beads↔Dolt sync and improves PowerShell profile setup on Windows.

- **Bug Fixes**
  - Gates `entire` `beforeSubmitPrompt` behind `MODME_ENTIRE_SUBMIT_HOOK=1` with `failClosed: false` and a 2s timeout.
  - Makes terminal attach silent: stamps then spawns background probes, so the prompt appears immediately.
  - Hardens `@beads/bd ready`: use `npx.cmd` (not `npx.ps1`) with a 20s timeout to avoid hung shells and Win32 `%1` errors.

- **New Features**
  - Adds `.cursor` hooks: `sessionStart` runs lean-ctx check + `km-session-bootstrap` (fail-open); `sessionEnd` performs beads↔Dolt sync and best-effort `entire` checkpoint; lightweight `afterFileEdit`/`stop` markers.
  - Introduces `scripts/modme-terminal-attach.ps1`: debounce + background health with JSONL logs; `-Foreground` for debugging.
  - Upgrades `scripts/install-pwsh-terminal-hooks.ps1`: patches both pwsh and Windows PowerShell (OneDrive-safe), adds a `devbox` guard, and auto soft-attach on terminal open.

<sup>Written for commit b7439d9014ee5f4fb7481fb6c0f00533fe021636. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Ditto190/modme-ui-01/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

